### PR TITLE
Add "Start Here" section with video content

### DIFF
--- a/docs-ref-conceptual/index.yml
+++ b/docs-ref-conceptual/index.yml
@@ -67,6 +67,10 @@ sections:
       title: Build a MEAN app with Cosmos DB
       image:
         src: https://docs.microsoft.com/azure/media/index/cosmosdb.svg
+- title: Start Here
+  items:
+  - type: markdown
+    text: <iframe src="https://channel9.msdn.com/Shows/Azure-for-Node-Developers/Welcome-to-the-Azure-for-Nodejs-Developer-Center/player" width="640" height="320" allowFullScreen="true" frameBorder="0"></iframe>
 - title: Free Node.js and Azure Video Training on Pluralsight
   items:
   - type: list


### PR DESCRIPTION
Added a new section to the landing page using a "markdown" section type, in order to add a video. In the future, we'll want to remove the iframe and convert this to Markdown instead of HTML. Unfortunately, we couldn't do that today because the landing page pipeline doesn't support any of our docs-specific Markdown extensions ;( Once that is resolved, we can fix this.