### PR TITLE
Update Quickstarts Web Apps link to use the Linux article

### DIFF
--- a/docs-ref-conceptual/node-azure-tools.md
+++ b/docs-ref-conceptual/node-azure-tools.md
@@ -13,7 +13,7 @@ ms.author: tarcher
 ---
 
 # Azure tools for Node.js developers
-We recommend these great tools to develop using Node.js on Azure, no matter what your operating system is.
+We recommend these great tools to develop using Node.js on Azure, no matter which operating system you use.
 
 ### Optional: Install the Azure CLI
 Azure CLI is optimized for managing Azure resources from the command line.

--- a/docs-ref-conceptual/toc.yml
+++ b/docs-ref-conceptual/toc.yml
@@ -5,7 +5,7 @@
       expanded: true
       items:
         - name: Web Apps
-          href: http://docs.microsoft.com/azure/app-service-web/app-service-web-get-started-nodejs
+          href: https://docs.microsoft.com/azure/app-service/containers/quickstart-nodejs
         - name: Serverless functions
           href: http://docs.microsoft.com/azure/azure-functions/functions-create-first-azure-function
         - name: Cosmos DB


### PR DESCRIPTION
This change points Node developers toward Linux by default rather than windows