### PR TITLE
Remove "get started" video from dev center home

### DIFF
--- a/docs-ref-conceptual/index.yml
+++ b/docs-ref-conceptual/index.yml
@@ -79,10 +79,6 @@ sections:
       title: Deploy to Linux and Kubernetes
       image:
         src: media/k8s_logo.svg
-- title: Get Started with Node.js on Azure
-  items:
-  - type: markdown
-    text: <iframe src="https://channel9.msdn.com/Shows/Azure-for-Node-Developers/Welcome-to-the-Azure-for-Nodejs-Developer-Center/player" width="640" height="360" allowFullScreen="true" frameBorder="0"></iframe>
 - title: Community
   items:
   - type: list


### PR DESCRIPTION
We may replace it with a new version soon, but this just pulls the old one down for the time being.

Request review from @rloutlaw  /cc: @johnpapa 