### PR TITLE
Fix typo

### DIFF
--- a/docs-ref-conceptual/index.yml
+++ b/docs-ref-conceptual/index.yml
@@ -237,7 +237,7 @@ sections:
       html: <p>Add Jenkins, CircleCI, or Travis to manage builds</p>
       image:
         src: https://docs.microsoft.com/media/common/i_scrum.svg
-      title: Continuos Integration
+      title: Continuous Integration
     - href: https://docs.microsoft.com/en-us/vsts/build-release/apps/cd/azure/azure-devops-project-nodejs?toc=%2Fvsts%2Fdeploy-azure%2Ftoc.json&bc=%2Fvsts%2Fdeploy-azure%2Fbreadcrumb%2Ftoc.json&view=vsts
       html: <p>Build and deploy Node apps from your VSTS</p>
       image:


### PR DESCRIPTION
Devops tile title was spelled incorrectly as Continuos