### PR TITLE
Refresh of JavaScript and Node.js Dev Center docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-## Azure Node.js SDK Documentation
+## Azure for JavaScript & Node.js developers Documentation
+
+This repository contains the documentation for the "Azure for JavaScript & Node.js" development center, available at https://docs.microsoft.com/javascript/azure/
 
 ### Legal Notices
 

--- a/bread/toc.yml
+++ b/bread/toc.yml
@@ -2,6 +2,6 @@
   href: /
   homepage: /
   items:
-  - name: Azure for JavaScript developers
+  - name: Azure for JavaScript & Node.js developers
     tocHref: /javascript/azure/
     topicHref: /javascript/azure/index

--- a/docs-ref-conceptual/index.yml
+++ b/docs-ref-conceptual/index.yml
@@ -17,20 +17,20 @@ metadata:
   ms.devlang: nodejs
   ms.service: multiple
 sections:
-- title: Get started fast 
+- title: Deploy your first Node.js app for free!
   items:
   - type: paragragh
-    html: <p>See how easy it is to get started with Node.js on Azure!
+    html: <p>You can deploy Node.js sample apps for free on Azure App Service</p>
   - type: list
     style: cards
     className: cardsM
     columns: 3
     items:
     - href: https://aka.ms/try-azure-node
-      html: <p>Deploy your first app in a free sandbox environment</p>
+      html: <p>Deploy your first app in a free sandbox environment on Azure App Service</p>
       image:
         src: https://docs.microsoft.com/en-us/media/common/i_get-started.svg
-      title: Get started free!
+      title: Deploy your first Node.js sample app
 - title: Host applications 
   items:
   - type: paragragh

--- a/docs-ref-conceptual/index.yml
+++ b/docs-ref-conceptual/index.yml
@@ -171,12 +171,6 @@ sections:
       html: <p>Add log statements to Azure App Service apps without redeploying</p>
       image:
         src: https://docs.microsoft.com/media/common/i_tools.svg
-      
-    - href: https://code.visualstudio.com/docs/nodejs/nodejs-debugging
-      html: <p>Guide for finding common Node.js errors</p>
-      image:
-        src: https://docs.microsoft.com/media/common/i_investigate.svg
-      title: Troubleshoot App Failure
     - title: Debug local Node.js apps in VS Code 
       href: https://code.visualstudio.com/docs/nodejs/nodejs-debugging
       html: <p>Automatically attach the debugger to running Node processes</p>

--- a/docs-ref-conceptual/index.yml
+++ b/docs-ref-conceptual/index.yml
@@ -177,11 +177,11 @@ sections:
       image:
         src: https://docs.microsoft.com/media/common/i_investigate.svg
       title: Troubleshoot App Failure
-    - href: https://code.visualstudio.com/docs/nodejs/nodejs-debugging
+    - title: Debug local Node.js apps in VS Code 
+      href: https://code.visualstudio.com/docs/nodejs/nodejs-debugging
       html: <p>Automatically attach the debugger to running Node processes</p>
       image:
-        src: https://docs.microsoft.com/media/logos/logo_vs-code.svg
-      title: Debugging in VS Code
+        src: https://docs.microsoft.com/media/logos/logo_vs-code.svg    
 - title: Messaging
   items:
   - type: paragragh

--- a/docs-ref-conceptual/index.yml
+++ b/docs-ref-conceptual/index.yml
@@ -34,7 +34,7 @@ sections:
 - title: Choose the right hosting for your app
   items:
   - type: paragragh
-    html: <p>Azure supports many hosting and application types for Javascript and Node.js developers. Chose your application type below, and we'll guide you how to build, deploy, and scale your application(s) on Azure.</p>
+    html: <p>Azure supports many hosting and application types for Javascript and Node.js developers. Chose your application type below, and we'll guide you on how to build, deploy, and scale your applications on Azure.</p>
   - type: list
     style: cards
     className: cardsM

--- a/docs-ref-conceptual/index.yml
+++ b/docs-ref-conceptual/index.yml
@@ -163,12 +163,12 @@ sections:
     items:
     - title: Remote debugging for Azure App Service (Preview)      
       href: https://medium.com/@auchenberg/introducing-remote-debugging-of-node-js-apps-on-azure-app-service-from-vs-code-in-public-preview-9b8d83a6e1f0
-      html: <p>Attach a debugger to your test or production node.js apps on Azure App Service.</p>
+      html: <p>Attach a debugger to your test or production Node.js apps on Azure App Service.</p>
       image:
         src: https://docs.microsoft.com/media/common/i_debug.svg    
     - title: Log Points in VS Code for Azure App Service
       href: https://code.visualstudio.com/blogs/2018/07/12/introducing-logpoints-and-auto-attach
-      html: <p>Add log statements to Azure App Service apps without redeploying</p>
+      html: <p>Add log statements to Azure App Service apps without redeploying from VS Code.</p>
       image:
         src: https://docs.microsoft.com/media/common/i_tools.svg
     - title: Debug local Node.js apps in VS Code 

--- a/docs-ref-conceptual/index.yml
+++ b/docs-ref-conceptual/index.yml
@@ -34,30 +34,30 @@ sections:
 - title: Choose the right hosting for your app
   items:
   - type: paragragh
-    html: <p>Azure supports many hosting and application types. Chose your application type below, and we'll guide you how to build, deploy, and scale your application(s) on Azure.</p>
+    html: <p>Azure supports many hosting and application types for Javascript and Node.js developers. Chose your application type below, and we'll guide you how to build, deploy, and scale your application(s) on Azure.</p>
   - type: list
     style: cards
     className: cardsM
     columns: 3
     items:
-    - href: https://code.visualstudio.com/tutorials/static-website/getting-started
-      title: Static sites with Azure Storage
-      html: <p>Deploy static apps like React, Angular, and Vue apps with Azure Storage</p>
+    - title: Static Web Apps, SPAs and Progressive Web Apps
+      html: <p>Deploy static apps built with frameworks like React, Angular, and Vue on Azure Storage</p>
+      href: https://code.visualstudio.com/tutorials/static-website/getting-started
       image:
         src: https://docs.microsoft.com/media/logos/logo_React.svg      
-    - href: https://code.visualstudio.com/tutorials/app-service-extension/getting-started
-      title: Full stack apps with Azure App Service
-      html: <p>Deploy full stack node.js apps like Express apps with Azure App Service</p>
+    - title: Full-stack Node.js-powered Web Apps and APIs
+      html: <p>Deploy full-stack node.js web apps and APIs built with frameworks like Express on Azure App Service</p>
+      href: https://code.visualstudio.com/tutorials/app-service-extension/getting-started
       image:
         src: https://docs.microsoft.com/media/logos/logo_vs-code.svg
-    - href: https://code.visualstudio.com/tutorials/docker-extension/getting-started
-      title: Containerized Docker apps with Azure App Service
-      html: <p>Deploy Docker containers and microservices with Azure App Service</p>
+    - title: Containerized Apps and Microservices with Docker
+      html: <p>Deploy containerized apps and microservices using Docker containers on Azure App Service</p>
+      href: https://code.visualstudio.com/tutorials/docker-extension/getting-started 
       image:
-        src: https://docs.microsoft.com/azure/media/index/ContainerInstances.svg
-    - href: https://code.visualstudio.com/tutorials/functions-extension/getting-started
-      title: Serverless apps and APIs with Azure Functions
-      html: <p>Deploy serverless apps and APIs with Azure Functions</p>
+        src: https://docs.microsoft.com/en-us/azure/docker/media/docker.png
+    - title: Serverless Apps and APIs
+      href: https://code.visualstudio.com/tutorials/functions-extension/getting-started    
+      html: <p>Deploy serverless Apps and APIs written in JavaScript on Azure Functions</p>
       image:
         src: https://docs.microsoft.com/azure/media/index/azurefunctions.svg
 - title: Store data

--- a/docs-ref-conceptual/index.yml
+++ b/docs-ref-conceptual/index.yml
@@ -161,16 +161,17 @@ sections:
     className: cardsM
     columns: 3
     items:
-    - href: https://code.visualstudio.com/blogs/2018/07/12/introducing-logpoints-and-auto-attach
-      html: <p>Add log statements to production apps without redeploying</p>
+    - title: Remote debugging for Azure App Service (Preview)      
+      href: https://medium.com/@auchenberg/introducing-remote-debugging-of-node-js-apps-on-azure-app-service-from-vs-code-in-public-preview-9b8d83a6e1f0
+      html: <p>Attach a debugger to your test or production node.js apps on Azure App Service.</p>
+      image:
+        src: https://docs.microsoft.com/media/common/i_debug.svg    
+    - title: Log Points in VS Code for Azure App Service
+      href: https://code.visualstudio.com/blogs/2018/07/12/introducing-logpoints-and-auto-attach
+      html: <p>Add log statements to Azure App Service apps without redeploying</p>
       image:
         src: https://docs.microsoft.com/media/common/i_tools.svg
-      title: Log Points
-    - title: Node.js Remote debugging (Preview)      
-      href: https://medium.com/@auchenberg/introducing-remote-debugging-of-node-js-apps-on-azure-app-service-from-vs-code-in-public-preview-9b8d83a6e1f0
-      html: <p>Attach a debugger to your test or production instances on Azure App Service.</p>
-      image:
-        src: https://docs.microsoft.com/media/common/i_debug.svg
+      
     - href: https://code.visualstudio.com/docs/nodejs/nodejs-debugging
       html: <p>Guide for finding common Node.js errors</p>
       image:

--- a/docs-ref-conceptual/index.yml
+++ b/docs-ref-conceptual/index.yml
@@ -1,10 +1,10 @@
 ### YamlMime:YamlDocument
 documentType: LandingData
-title: Azure for JavaScript developers
+title: Azure for JavaScript & Node.js developers
 metadata:
-  title: Azure for Node.js developers - Tutorials, tools, and SDK reference
-  description: Get started developing apps with Azure using tutorials, modules, and tools written for Node.js developers.
-  keywords: Azure, Node.js, SDK, API, npm
+  title: Azure for JavaScript & Node.js developers - Tutorials, tools, and SDK reference
+  description: Get started developing apps with Azure using tutorials, modules, and tools written for JavaScript & Node.js developers.
+  keywords: Azure, JavaScript, Node.js, SDK, API, NPM
   author: rloutlaw
   ms.author: routlaw
   manager: douge

--- a/docs-ref-conceptual/index.yml
+++ b/docs-ref-conceptual/index.yml
@@ -166,11 +166,11 @@ sections:
       image:
         src: https://docs.microsoft.com/media/common/i_tools.svg
       title: Log Points
-    - href: https://code.visualstudio.com/docs/nodejs/nodejs-debugging#_remote-debugging
-      html: <p>Attach a debugger to your test or production instances</p>
+    - title: Node.js Remote debugging (Preview)      
+      href: https://medium.com/@auchenberg/introducing-remote-debugging-of-node-js-apps-on-azure-app-service-from-vs-code-in-public-preview-9b8d83a6e1f0
+      html: <p>Attach a debugger to your test or production instances on Azure App Service.</p>
       image:
         src: https://docs.microsoft.com/media/common/i_debug.svg
-      title: Remote debugging
     - href: https://code.visualstudio.com/docs/nodejs/nodejs-debugging
       html: <p>Guide for finding common Node.js errors</p>
       image:

--- a/docs-ref-conceptual/index.yml
+++ b/docs-ref-conceptual/index.yml
@@ -31,35 +31,35 @@ sections:
       image:
         src: https://docs.microsoft.com/en-us/media/common/i_get-started.svg
       title: Deploy your first Node.js sample app
-- title: Host applications 
+- title: Choose the right hosting for your app
   items:
   - type: paragragh
-    html: <p>Build, deploy, and scale your Node.js applications on Azure
+    html: <p>Azure supports many hosting and application types. Chose your application type below, and we'll guide you how to build, deploy, and scale your application(s) on Azure.</p>
   - type: list
     style: cards
     className: cardsM
     columns: 3
     items:
     - href: https://code.visualstudio.com/tutorials/static-website/getting-started
+      title: Static sites with Azure Storage
+      html: <p>Deploy static apps like React, Angular, and Vue apps with Azure Storage</p>
       image:
-        src: https://docs.microsoft.com/media/logos/logo_React.svg
-      title: Static site
-      html: <p>Host your React, Angular, and Vue apps with Azure Storage</p>
+        src: https://docs.microsoft.com/media/logos/logo_React.svg      
     - href: https://code.visualstudio.com/tutorials/app-service-extension/getting-started
-      html: <p>Deploy Express apps with App Service</p>
+      title: Full stack apps with Azure App Service
+      html: <p>Deploy full stack node.js apps like Express apps with Azure App Service</p>
       image:
         src: https://docs.microsoft.com/media/logos/logo_vs-code.svg
-      title: Full stack
     - href: https://code.visualstudio.com/tutorials/docker-extension/getting-started
-      html: <p>Build and deploy docker containers and microservices on Azure</p>
+      title: Containerized apps with Azure App Service
+      html: <p>Deploy Docker containers and microservices with Azure App Service</p>
       image:
         src: https://docs.microsoft.com/azure/media/index/ContainerInstances.svg
-      title: Container apps
     - href: https://code.visualstudio.com/tutorials/functions-extension/getting-started
-      html: <p>Go serverless with Azure Functions</p>
+      title: Serverless apps and APIs
+      html: <p>Deploy serverless apps and APIs with Azure Functions</p>
       image:
         src: https://docs.microsoft.com/azure/media/index/azurefunctions.svg
-      title: Serverless apps and APIs
 - title: Store data
   items:
   - type: paragragh

--- a/docs-ref-conceptual/index.yml
+++ b/docs-ref-conceptual/index.yml
@@ -56,7 +56,7 @@ sections:
       image:
         src: https://docs.microsoft.com/azure/media/index/ContainerInstances.svg
     - href: https://code.visualstudio.com/tutorials/functions-extension/getting-started
-      title: Serverless apps and APIs
+      title: Serverless apps and APIs with Azure Functions
       html: <p>Deploy serverless apps and APIs with Azure Functions</p>
       image:
         src: https://docs.microsoft.com/azure/media/index/azurefunctions.svg

--- a/docs-ref-conceptual/index.yml
+++ b/docs-ref-conceptual/index.yml
@@ -51,7 +51,7 @@ sections:
       image:
         src: https://docs.microsoft.com/media/logos/logo_vs-code.svg
     - href: https://code.visualstudio.com/tutorials/docker-extension/getting-started
-      title: Containerized apps with Azure App Service
+      title: Containerized Docker apps with Azure App Service
       html: <p>Deploy Docker containers and microservices with Azure App Service</p>
       image:
         src: https://docs.microsoft.com/azure/media/index/ContainerInstances.svg

--- a/docs-ref-conceptual/toc.yml
+++ b/docs-ref-conceptual/toc.yml
@@ -1,4 +1,4 @@
-- name: Azure for JavaScript developers
+- name: Azure for JavaScript & Node.js developers
   href: index.yml
   items:
   - name: Overview


### PR DESCRIPTION
Initial work on refresh of JavaScript and Node.js Dev Center docs.

**Changes:**
- Rename to "Azure for JavaScript & Node.js developers"
- Refresh of hosting types
- Cleaned up Debugging section

