### PR TITLE
Update link to Azure Remote Debugging docs

### DIFF
--- a/docs-ref-conceptual/index.yml
+++ b/docs-ref-conceptual/index.yml
@@ -161,8 +161,8 @@ sections:
     className: cardsM
     columns: 3
     items:
-    - title: Remote debugging for Azure App Service (Preview)      
-      href: https://medium.com/@auchenberg/introducing-remote-debugging-of-node-js-apps-on-azure-app-service-from-vs-code-in-public-preview-9b8d83a6e1f0
+    - title: Remote debugging for Azure App Service
+      href: https://vscode-docs-master.azurewebsites.net/docs/azure/remote-debugging
       html: <p>Attach a debugger to your test or production Node.js apps on Azure App Service.</p>
       image:
         src: https://docs.microsoft.com/media/common/i_debug.svg    

--- a/docs-ref-conceptual/index.yml
+++ b/docs-ref-conceptual/index.yml
@@ -162,7 +162,7 @@ sections:
     columns: 3
     items:
     - title: Remote debugging for Azure App Service
-      href: https://vscode-docs-master.azurewebsites.net/docs/azure/remote-debugging
+      href: https://code.visualstudio.com/docs/azure/remote-debugging
       html: <p>Attach a debugger to your test or production Node.js apps on Azure App Service.</p>
       image:
         src: https://docs.microsoft.com/media/common/i_debug.svg    


### PR DESCRIPTION
This updates the link to the Azure Remote Debugging docs, as the feature is no longer in preview.