### PR TITLE
Update template for xref testing.

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -46,7 +46,7 @@
     {
       "path_to_root": "_themes",
       "url": "https://github.com/Microsoft/templates.docs.msft",
-      "branch": "master",
+      "branch": "pr-11470",
       "branch_mapping": {}
     }
   ],


### PR DESCRIPTION
DO NOT MERGE TO MASTER.

This is simply for xref testing purposes to see if there is a template issue. Due to the way the xref service works and the way that the repository is set up, this cannot be tested locally.

The OPS Build process for PR branches should run a build for this and generate the content, which we can test against.