### PR TITLE
Placing arm-servicebus into the management Section of the ToC

### DIFF
--- a/docs-ref-mapping/reference.yml
+++ b/docs-ref-mapping/reference.yml
@@ -867,13 +867,13 @@
         children:
         - azure-sb
         - '@azure/service-bus'
-        - '@azure/arm-servicebus'
       - name: Management
         uid: azure.nodejs.sdk.landingPage.services.servicebus.Management
         landingPageType: Service
         children:
         - azure-arm-sb
         - azure-asm-sb
+        - '@azure/arm-servicebus'
     - name: Service Fabric
       uid: azure.nodejs.sdk.landingpage.services.servicefabric
       href: ~/docs-ref-services/service-fabric.md


### PR DESCRIPTION
This is to go along with the fact that `@azure/azure-servicebus` and `@azure/azure-eventhubs` both were dropped from the CI. Robert Outlook fixed this. 

This is just correcting the landing location of one of those two GA packages.