### PR TITLE
Addressing issue in reference.yml for Speech service

### DIFF
--- a/docs-ref-mapping/reference.yml
+++ b/docs-ref-mapping/reference.yml
@@ -312,7 +312,6 @@
         - '@azure/cognitiveservices-textanalytics'
       - name: Speech Service
         uid: microsoft-cognitiveservices-speech-sdk
-        landingPageType: Service
         href: ~/docs-ref-services/speech-service.md
         children:
         - microsoft-cognitiveservices-speech-sdk


### PR DESCRIPTION
Addressing issue in reference.yml that prevents the sidebar for the speech-service.md from rendering.

* Removed: `landingPageType`, left `href`