### PR TITLE
Fix Legacy Moniker Build

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -111,7 +111,6 @@
         "TopLevelTOC": "previous-packages/docs-ref-mapping/reference.yml",
         "ReferenceTOC": "previous-packages/docs-ref-autogen/toc.yml",
         "ConceptualTOCUrl": "/azure/javascript/toc.json",
-        "ReferenceTOCUrl": "/javascript/api/azure_node_ref_toc_legacy/toc.json?view=azure-node-legacy",
         "OutputFolder": "previous-packages/docs-ref-autogen/overview",
         "HideEmptyNode": false,
         "ContainerPageMetadata": {

--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -7,7 +7,8 @@
       "locale": "en-us",
       "moniker_ranges": [
         "azure-node-latest",
-        "azure-node-preview"
+        "azure-node-preview",
+        "azure-node-legacy"
       ],
       "open_to_public_contributors": true,
       "type_mapping": {
@@ -98,6 +99,20 @@
         "ConceptualTOCUrl": "/azure/javascript/toc.json",
         "ReferenceTOCUrl": "/javascript/api/azure_node_ref_toc_preview/toc.json?view=azure-node-preview",
         "OutputFolder": "preview-packages/docs-ref-autogen/overview",
+        "HideEmptyNode": false,
+        "ContainerPageMetadata": {
+          "langs": [
+            "js"
+          ]
+        },
+        "ContainerPageYamlMime": "YamlMime:UniversalReference"
+      },
+      {
+        "TopLevelTOC": "previous-packages/docs-ref-mapping/reference.yml",
+        "ReferenceTOC": "previous-packages/docs-ref-autogen/toc.yml",
+        "ConceptualTOCUrl": "/azure/javascript/toc.json",
+        "ReferenceTOCUrl": "/javascript/api/azure_node_ref_toc_legacy/toc.json?view=azure-node-legacy",
+        "OutputFolder": "previous-packages/docs-ref-autogen/overview",
         "HideEmptyNode": false,
         "ContainerPageMetadata": {
           "langs": [

--- a/docfx.json
+++ b/docfx.json
@@ -21,6 +21,16 @@
       },
       {
         "files": [
+          "**/*.yml"
+        ],
+        "src": "previous-packages/docs-ref-autogen/overview",
+        "dest": "api/overview/azure",
+        "group": "legacy",
+        "version": "azure-node-legacy"
+      },
+
+      {
+        "files": [
           "**/toc.md",
           "**/toc.yml"
         ],
@@ -41,6 +51,17 @@
       },
       {
         "files": [
+          "**/toc.md",
+          "**/toc.yml"
+        ],
+        "src": "previous-packages/docs-ref-autogen",
+        "dest": "api/azure_node_ref_toc",
+        "group": "legacy",
+        "version": "azure-node-legacy"
+      },
+
+      {
+        "files": [
           "**/*.md",
           "**/*.yml"
         ],
@@ -59,6 +80,17 @@
         "group": "preview",
         "version": "azure-node-preview"
       },
+      {
+        "files": [
+          "**/*.md",
+          "**/*.yml"
+        ],
+        "src": "docs-ref-services",
+        "dest": "api/overview/azure",
+        "group": "legacy",
+        "version": "azure-node-legacy"
+      },
+
       {
         "files": [
           "**/*.md"
@@ -87,6 +119,20 @@
       },
       {
         "files": [
+          "**/*.md"
+        ],
+        "src": "docs-ref-conceptual",
+        "dest": "azure",
+        "group": "legacy",
+        "version": "azure-node-legacy",
+        "exclude": [
+          "**/obj/**",
+          "**/includes/**"
+        ]
+      },
+
+      {
+        "files": [
           "**/*.md",
           "**/*.yml"
         ],
@@ -111,6 +157,20 @@
           "**/toc.yml"
         ]
       },
+      {
+        "files": [
+          "**/*.md",
+          "**/*.yml"
+        ],
+        "src": "previous-packages/docs-ref-autogen",
+        "dest": "api",
+        "group": "legacy",
+        "version": "azure-node-legacy",
+        "exclude": [
+          "**/toc.yml"
+        ]
+      },
+
       {
         "files": [
           "**/*.yml"
@@ -132,6 +192,19 @@
         "dest": "azure/azure_nodejs_bread_preview",
         "group": "preview",
         "version": "azure-node-preview",
+        "exclude": [
+          "**/obj/**",
+          "**/includes/**"
+        ]
+      },
+      {
+        "files": [
+          "**/*.yml"
+        ],
+        "src": "bread",
+        "dest": "azure/azure_nodejs_bread_legacy",
+        "group": "legacy",
+        "version": "azure-node-legacy",
         "exclude": [
           "**/obj/**",
           "**/includes/**"
@@ -168,12 +241,31 @@
         "dest": "azure",
         "group": "preview",
         "version": "azure-node-preview"
+      },
+      {
+        "files": [
+          "**/*.png",
+          "**/*.jpg",
+          "**/*.svg"
+        ],
+        "exclude": [
+          "**/obj/**",
+          "**/includes/**"
+        ],
+        "src": "docs-ref-conceptual",
+        "dest": "azure",
+        "group": "legacy",
+        "version": "azure-node-legacy"
       }
     ],
     "groups": {
       "preview": {
         "dest": "preview",
         "moniker_range": "azure-node-preview"
+      },
+      "legacy": {
+        "dest": "stable",
+        "moniker_range": "azure-node-legacy"
       },
       "stable": {
         "dest": "stable",

--- a/docfx.json
+++ b/docfx.json
@@ -264,7 +264,7 @@
         "moniker_range": "azure-node-preview"
       },
       "legacy": {
-        "dest": "stable",
+        "dest": "legacy",
         "moniker_range": "azure-node-legacy"
       },
       "stable": {


### PR DESCRIPTION
Update docfx.json, update the monikers. End goal is that the moniker `azure-node-legacy` correctly renders.