### PR TITLE
Node JS Documentation Cleanup

### DIFF
--- a/docs-ref-services/activedirectory.md
+++ b/docs-ref-services/activedirectory.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Active Directory Modules for JavaScript
-description: Reference for Azure Active Directory Modules for JavaScript
+title: Azure Active Directory Modules for Node.js
+description: Reference for Azure Active Directory Modules for Node.js
 author: celestedg
 ms.author: celested
 manager: mtillman
@@ -11,14 +11,14 @@ ms.technology: azure
 ms.devlang: nodejs
 ---
 
-# Azure Active Directory modules for JavaScript
+# Azure Active Directory modules for Node.js
 
 ## Overview
 
 > [!IMPORTANT]
 > We strongly recommend that you use [Microsoft Graph](https://graph.microsoft.io/) instead of Azure AD Graph API to access Azure Active Directory resources. Our development efforts are now concentrated on Microsoft Graph and no further enhancements are planned for Azure AD Graph API. There are a very limited number of scenarios for which Azure AD Graph API might still be appropriate; for more information, see the [Microsoft Graph or the Azure AD Graph](https://dev.office.com/blogs/microsoft-graph-or-azure-ad-graph) blog post in the Office Dev Center.
 
-The [Azure Active Directory Authentication Library (ADAL) for JavaScript](https://www.npmjs.com/package/adal-node) enables JavaScript applications to authenticate to AAD in order to access AAD protected web resources.
+The [Azure Active Directory Authentication Library (ADAL) for Node.js](https://www.npmjs.com/package/adal-node) enables Node.js applications to authenticate to AAD in order to access AAD protected web resources.
 
 ## Client package
 
@@ -34,7 +34,7 @@ npm install adal-node
 
 This example from the [client credentials sample](https://github.com/MSOpenTech/azure-activedirectory-library-for-nodejs/blob/master/sample/client-credentials-sample.js) illustrates server-to-server authentication via client credentials.
 
-```JavaScript
+```Node.js
 const adal = require('adal-node').AuthenticationContext;
 
 const authorityHostUrl = 'https://login.windows.net';
@@ -68,4 +68,4 @@ context.acquireTokenWithClientCredentials(
 | [Securing a web API with Azure AD](https://azure.microsoft.com/resources/samples/active-directory-node-webapi/) | A NodeJS web API that is secured using Azure AD and OAuth 2.0 access tokens. |
 | [Integrating Azure AD into a NodeJS web application](https://azure.microsoft.com/resources/samples/active-directory-node-webapp-openidconnect/) | A NodeJS web application that authenticates Azure AD users with OpenID Connect. |
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [Node.JS samples](https://azure.microsoft.com/resources/samples/?platform=nodejs).

--- a/docs-ref-services/activedirectory.md
+++ b/docs-ref-services/activedirectory.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Active Directory Modules for Node.js
-description: Reference for Azure Active Directory Modules for Node.js
+title: Azure Active Directory Modules for JavaScript
+description: Reference for Azure Active Directory Modules for JavaScript
 author: celestedg
 ms.author: celested
 manager: mtillman
@@ -11,14 +11,14 @@ ms.technology: azure
 ms.devlang: nodejs
 ---
 
-# Azure Active Directory modules for Node.js
+# Azure Active Directory modules for JavaScript
 
 ## Overview
 
 > [!IMPORTANT]
 > We strongly recommend that you use [Microsoft Graph](https://graph.microsoft.io/) instead of Azure AD Graph API to access Azure Active Directory resources. Our development efforts are now concentrated on Microsoft Graph and no further enhancements are planned for Azure AD Graph API. There are a very limited number of scenarios for which Azure AD Graph API might still be appropriate; for more information, see the [Microsoft Graph or the Azure AD Graph](https://dev.office.com/blogs/microsoft-graph-or-azure-ad-graph) blog post in the Office Dev Center.
 
-The [Azure Active Directory Authentication Library (ADAL) for Node.js](https://www.npmjs.com/package/adal-node) enables Node.js applications to authenticate to AAD in order to access AAD protected web resources.
+The [Azure Active Directory Authentication Library (ADAL) for JavaScript](https://www.npmjs.com/package/adal-node) enables JavaScript applications to authenticate to AAD in order to access AAD protected web resources.
 
 ## Client package
 
@@ -34,7 +34,7 @@ npm install adal-node
 
 This example from the [client credentials sample](https://github.com/MSOpenTech/azure-activedirectory-library-for-nodejs/blob/master/sample/client-credentials-sample.js) illustrates server-to-server authentication via client credentials.
 
-```javascript
+```JavaScript
 const adal = require('adal-node').AuthenticationContext;
 
 const authorityHostUrl = 'https://login.windows.net';
@@ -68,4 +68,4 @@ context.acquireTokenWithClientCredentials(
 | [Securing a web API with Azure AD](https://azure.microsoft.com/resources/samples/active-directory-node-webapi/) | A NodeJS web API that is secured using Azure AD and OAuth 2.0 access tokens. |
 | [Integrating Azure AD into a NodeJS web application](https://azure.microsoft.com/resources/samples/active-directory-node-webapp-openidconnect/) | A NodeJS web application that authenticates Azure AD users with OpenID Connect. |
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/advisor.md
+++ b/docs-ref-services/advisor.md
@@ -33,8 +33,11 @@ npm install @azure/arm-advisor
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-advisor)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the Package](https://www.npmjs.com/package/@azure/arm-advisor).
+
+
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-advisor)
 
 ## Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/advisor.md
+++ b/docs-ref-services/advisor.md
@@ -31,13 +31,9 @@ Install the Azure Advisor npm module
 npm install @azure/arm-advisor
 ```
 
-### Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the Package](https://www.npmjs.com/package/@azure/arm-advisor).
-
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-advisor)
-
 ## Samples
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-advisor)
+
+
+* For more code samples that use various Azure packages, explore the [Node.JS samples](https://docs.microsoft.com/samples/browse/?languages=nodejs).

--- a/docs-ref-services/advisor.md
+++ b/docs-ref-services/advisor.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Advisor modules for Node.js
-description: Reference for Azure Advisor modules for Node.js
+title: Azure Advisor modules for JavaScript
+description: Reference for Azure Advisor modules for JavaScript
 author: KumudD
 ms.author: kumud
 manager: jeconnoc
@@ -10,7 +10,7 @@ ms.devlang: nodejs
 ms.service: Advisor
 ---
 
-# Azure Advisor modules for Node.js
+# Azure Advisor modules for JavaScript
 
 ## Overview
 
@@ -28,28 +28,13 @@ With Advisor, you can:
 Install the Azure Advisor npm module
 
 ```bash
-npm install azure-arm-advisor
+npm install @azure/arm-advisor
 ```
 
 ### Example
 
-This example displays the list of recommendations from Azure Advisor.
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const advisorManagement = require('azure-arm-advisor');
-
-const subscriptionId = 'your-subscription-id';
-
-msRestAzure.interactiveLogin().then(credentials => {
-  const client = new advisorManagement(credentials, subscriptionId);
-  client.recommendations.list().then(recommendations => {
-    console.log('List of recommendations:');
-    console.dir(recommendations, {depth: null, colors: true});
-  });
-});
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-advisor)
 
 ## Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/analysis-services.md
+++ b/docs-ref-services/analysis-services.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Analysis Services modules for Node.js
-description: Reference for Azure Analysis Services modules for Node.js
+title: Azure Analysis Services modules for JavaScript
+description: Reference for Azure Analysis Services modules for JavaScript
 author: Minewiskan
 ms.author: owend
 manager: kfile
@@ -12,10 +12,10 @@ ms.devlang: nodejs
 ms.service: Analysis Services
 ---
 
-# Azure Analysis Services modules for Node.js
+# Azure Analysis Services modules for JavaScript
 
 ## Overview
-This package provides a Node.js module that makes it easy to manage Microsoft Azure Analysis Services.
+This package provides a JavaScript module that makes it easy to manage Microsoft Azure Analysis Services.
 
 ## Management package
 
@@ -24,29 +24,13 @@ This package provides a Node.js module that makes it easy to manage Microsoft Az
 Install the Azure Analysis Services npm module
 
 ```bash
-npm install azure-arm-analysisservices
+npm install @azure/arm-analysisservices
 ```
 
 ### Example
 
-This example lists all available Analysis Service servers.
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const analysisServicesManagement = require('azure-arm-analysisservices');
-
-const subscriptionId = 'your-subscription-id';
-let analysisServicesClient;
-
-msRestAzure.interactiveLogin().then(credentials => {
-  analysisServicesClient = new analysisServicesManagement(credentials, subscriptionId);
-
-  analysisServicesClient.servers
-    .list()
-    .then(servers => console.log('Retrieved analysis services servers: ', servers));
-});
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-analysisservices)
 
 ## Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/analysis-services.md
+++ b/docs-ref-services/analysis-services.md
@@ -29,8 +29,8 @@ npm install @azure/arm-analysisservices
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-analysisservices)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-analysisservices)
 
 ## Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/analysis-services.md
+++ b/docs-ref-services/analysis-services.md
@@ -27,10 +27,8 @@ Install the Azure Analysis Services npm module
 npm install @azure/arm-analysisservices
 ```
 
-### Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-analysisservices)
-
 ## Samples
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-analysisservices)
+
+* For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/appservice.md
+++ b/docs-ref-services/appservice.md
@@ -1,6 +1,6 @@
 ---
-title: Azure App Service modules for Node.js
-description: Reference for Azure App Service modules for Node.js
+title: Azure App Service modules for JavaScript
+description: Reference for Azure App Service modules for JavaScript
 author: SyntaxC4
 ms.author: cfowler
 manager: jhubbard
@@ -12,7 +12,7 @@ ms.devlang: nodejs
 ms.service: appservice
 ---
 
-# Azure App Service modules for Node.js
+# Azure App Service modules for JavaScript
 
 ## Overview
 
@@ -24,43 +24,21 @@ App Service includes the web and mobile capabilities that we previously delivere
 
 ### Install the npm package
 
-Install the Azure App Service module for Node.js
+Install the Azure App Service module for JavaScript
 
 ```bash
-npm install azure-arm-website
+npm install @azure/arm-appservice
 ```
 
 ### Example
 
-This example creates a website on Azure using Node.js.
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const webSiteManagementClient = require('azure-arm-website');
-
-const subscriptionId = 'your-subscription-id';
-const website = 'website001';
-const resourceGroup = 'your-resource-group';
-const hostingPlan = 'testHostingPlan';
-let webSiteClient;
-
-msRestAzure.interactiveLogin().then(credentials => {
-  webSiteClient = new webSiteManagementClient(credentials, subscriptionId);
-  createWebSite(website).then(website => console.log('Web Site created successfully', website));
-});
-
-function createWebSite(webSiteName) {
-  const parameters = { location: 'westus', serverFarmId: hostingPlan };
-  console.log(`Creating web site:  ${webSiteName}`);
-  return webSiteClient.webApps.createOrUpdate(resourceGroup, webSiteName, parameters, null);
-}
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-appservice)
 
 ## Samples
 
-- [App Service Mobile completed quickstart for Node.js backend](https://azure.microsoft.com/resources/samples/app-service-mobile-nodejs-backend-quickstart/)
-- [Manage Azure websites with Node.js](https://azure.microsoft.com/resources/samples/app-service-web-nodejs-manage/)
+- [App Service Mobile completed quickstart for JavaScript backend](https://azure.microsoft.com/resources/samples/app-service-mobile-nodejs-backend-quickstart/)
+- [Manage Azure websites with JavaScript](https://azure.microsoft.com/resources/samples/app-service-web-nodejs-manage/)
 - [MEAN.js sample for Azure App Service](https://azure.microsoft.com/resources/samples/meanjs/)
 - [FoodTrucks - Node API App for Azure App Service](https://azure.microsoft.com/resources/samples/app-service-api-node-food-trucks/)
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/appservice.md
+++ b/docs-ref-services/appservice.md
@@ -32,7 +32,7 @@ npm install @azure/arm-appservice
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-appservice)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-appservice)
 
 ## Samples
 
@@ -41,4 +41,4 @@ Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-ap
 - [MEAN.js sample for Azure App Service](https://azure.microsoft.com/resources/samples/meanjs/)
 - [FoodTrucks - Node API App for Azure App Service](https://azure.microsoft.com/resources/samples/app-service-api-node-food-trucks/)
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/appservice.md
+++ b/docs-ref-services/appservice.md
@@ -30,15 +30,13 @@ Install the Azure App Service module for JavaScript
 npm install @azure/arm-appservice
 ```
 
-### Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-appservice)
-
 ## Samples
+
+- Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-appservice)
 
 - [App Service Mobile completed quickstart for JavaScript backend](https://azure.microsoft.com/resources/samples/app-service-mobile-nodejs-backend-quickstart/)
 - [Manage Azure websites with JavaScript](https://azure.microsoft.com/resources/samples/app-service-web-nodejs-manage/)
 - [MEAN.js sample for Azure App Service](https://azure.microsoft.com/resources/samples/meanjs/)
 - [FoodTrucks - Node API App for Azure App Service](https://azure.microsoft.com/resources/samples/app-service-api-node-food-trucks/)
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/authorization.md
+++ b/docs-ref-services/authorization.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Authorization modules for Node.js
-description: Reference for Azure Authorization modules for Node.js
+title: Azure Authorization modules for JavaScript
+description: Reference for Azure Authorization modules for JavaScript
 author: rloutlaw
 ms.author: ROutlaw
 manager: angrobe
@@ -12,7 +12,7 @@ ms.devlang: nodejs
 ms.service: Authorization
 ---
 
-# Azure Authorization modules for Node.js
+# Azure Authorization modules for JavaScript
 
 ## Overview
 
@@ -20,35 +20,21 @@ Azure App Service Authentication / Authorization is a feature that provides a wa
 
 ## Management package
 
-Use npm to install the Azure Authorization modules for Node.js
+Use npm to install the Azure Authorization modules for JavaScript
 
 ### Install the npm module
 
 Install the Azure authorization npm module
 
 ```bash
-npm install azure-arm-authorization
+npm install @azure/ms-rest-nodeauth
 ```
 
 ### Example
 
-This example lists all role assignments for the requested resource group.
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-authorization)
 
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const authorizationManagement = require('azure-arm-authorization');
-
-const resourceGroup = 'resource-group-name';
-const subscriptionId = 'your-subscription-id';
-
-msRestAzure.interactiveLogin().then(credentials => {
- const client = new authorizationManagement(credentials, subscriptionId);
- client.roleAssignments.listForResourceGroup(resourceGroupName).then(result => {
-   console.log(result);
- });
-});
-```
 
 ## Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/authorization.md
+++ b/docs-ref-services/authorization.md
@@ -27,14 +27,14 @@ Use npm to install the Azure Authorization modules for JavaScript
 Install the Azure authorization npm module
 
 ```bash
-npm install @azure/ms-rest-nodeauth
+npm install @azure/arm-authorization
 ```
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-authorization)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-authorization)
 
 
 ## Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/authorization.md
+++ b/docs-ref-services/authorization.md
@@ -30,11 +30,8 @@ Install the Azure authorization npm module
 npm install @azure/arm-authorization
 ```
 
-### Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-authorization)
-
-
 ## Samples
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-authorization)
+
+* For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/automation.md
+++ b/docs-ref-services/automation.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Automation Modules for Node.js
-description: Reference for Azure Automation Modules for Node.js
+title: Azure Automation Modules for JavaScript
+description: Reference for Azure Automation Modules for JavaScript
 author: eamonoreilly
 ms.author: eamono
 manager: nirb
@@ -10,7 +10,7 @@ ms.devlang: nodejs
 ms.service: Automation
 ---
 
-# Azure Automation Modules for Node.js
+# Azure Automation Modules for JavaScript
 
 ## Overview
 
@@ -20,35 +20,16 @@ Azure Automation provides a way for users to automate the manual, long-running, 
 
 ### Install the modules with npm
 
-Use npm to install the Azure Automation modules for Node.js
+Use npm to install the Azure Automation modules for JavaScript
 
 ```bash
-npm install azure-arm-automation
+npm install @azure/arm-automation
 ```
 
 ### Example
 
-This example lists the automation accounts.
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const AutomationManagement = require('azure-arm-automation');
-
-const subcriptionId = 'your-subscription-id';
-const resourceGroup = 'your-resource-group';
-
-msRestAzure
-  .interactiveLogin()
-  .then(credentials => {
-    const client = new AutomationManagement(credentials, subcriptionId);
-    return client.automationAccounts.listByResourceGroup(resourceGroup);
-  })
-  .then(automationAccounts =>
-    console.dir(automationAccounts, { depth: null, colors: true })
-  )
-  .catch(err => console.log(err));
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-automation)
 
 ## Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/automation.md
+++ b/docs-ref-services/automation.md
@@ -26,10 +26,8 @@ Use npm to install the Azure Automation modules for JavaScript
 npm install @azure/arm-automation
 ```
 
-### Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-automation)
-
 ## Samples
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-automation)
+
+* For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/automation.md
+++ b/docs-ref-services/automation.md
@@ -28,8 +28,8 @@ npm install @azure/arm-automation
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-automation)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-automation)
 
 ## Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/backup.md
+++ b/docs-ref-services/backup.md
@@ -28,8 +28,8 @@ npm install @azure/arm-recoveryservicesbackup
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-recoveryservicesbackup)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-recoveryservicesbackup)
 
 ## Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/backup.md
+++ b/docs-ref-services/backup.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Backup Modules for Node.js
-description: Reference for Azure Backup Modules for Node.js
+title: Azure Backup Modules for JavaScript
+description: Reference for Azure Backup Modules for JavaScript
 author: dcurwin
 ms.author: dacurwin
 manager: carmonm
@@ -10,7 +10,7 @@ ms.devlang: nodejs
 ms.service: Backup
 ---
 
-# Azure Backup Modules for Node.js
+# Azure Backup Modules for JavaScript
 
 ## Overview
 
@@ -20,37 +20,16 @@ Azure Backup is the Azure-based service you can use to back up (or protect) and 
 
 ### Install the modules with npm
 
-Use npm to install the Azure Backup modules for Node.js
+Use npm to install the Azure Backup modules for JavaScript
 
 ```bash
-npm install azure-arm-recoveryservicesbackup
+npm install @azure/arm-recoveryservicesbackup
 ```
 
 ### Example
 
-This example lists the recovery jobs for a given vault and resource group.
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const RecoveryServicesBackupManagement = require('azure-arm-recoveryservicesbackup');
-
-const subcriptionId = 'your-subscription-id';
-const vault = 'your-recovery-service-vault';
-const resourceGroupName = 'your-resource-group';
-
-msRestAzure
-  .interactiveLogin()
-  .then(credentials => {
-    const client = new RecoveryServicesBackupManagement(
-      credentials,
-      subcriptionId
-    );
-    return client.jobs.list(vault, resourceGroupName);
-  })
-  .then(jobs => console.dir(jobs, { depth: null, colors: true }))
-  .catch(err => console.log(err));
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-recoveryservicesbackup)
 
 ## Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/backup.md
+++ b/docs-ref-services/backup.md
@@ -26,10 +26,8 @@ Use npm to install the Azure Backup modules for JavaScript
 npm install @azure/arm-recoveryservicesbackup
 ```
 
-### Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-recoveryservicesbackup)
-
 ## Samples
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-recoveryservicesbackup)
+
+* For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/batchai.md
+++ b/docs-ref-services/batchai.md
@@ -1,6 +1,6 @@
 ---
-title: Batch AI Modules for Node.js
-description: Reference for Batch AI modules for Node.js
+title: Batch AI Modules for JavaScript
+description: Reference for Batch AI modules for JavaScript
 author: garyericson
 ms.author: garye
 manager: cjgronlund 
@@ -12,7 +12,7 @@ ms.devlang: nodejs
 ms.service: batch-ai
 ---
 
-# Batch AI Modules for Node.js
+# Batch AI Modules for JavaScript
 
 >[!NOTE]
 >**Azure Batch AI service has been retired.** The capabilities of Azure Batch AI are now available as a managed compute target in Azure Machine Learning service. For more information, see [What happened to Batch AI?](https://aka.ms/batchai-retirement)

--- a/docs-ref-services/billing.md
+++ b/docs-ref-services/billing.md
@@ -24,12 +24,12 @@ To use this API, the account admin must opt in via the Azure portal. See [Manage
 Install the Azure Billing npm module 
 
 ```bash
-npm install @azure/ms-rest-nodeauth
+npm install @azure/arm-billing
 ```
 ### Example 
  
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-billing)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-billing)
 
 ## Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/billing.md
+++ b/docs-ref-services/billing.md
@@ -26,10 +26,9 @@ Install the Azure Billing npm module
 ```bash
 npm install @azure/arm-billing
 ```
-### Example 
- 
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-billing)
 
 ## Samples
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-billing)
+
+* For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/billing.md
+++ b/docs-ref-services/billing.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Billing modules for Node.js
-description: Reference for Azure Billing modules for Node.js
+title: Azure Billing modules for JavaScript
+description: Reference for Azure Billing modules for JavaScript
 author: tfitzmac
 ms.author: tomfitz
 manager: timlt
@@ -12,7 +12,7 @@ ms.product:
 ms.technology:
 ---
 
-# Azure Billing modules for Node.js
+# Azure Billing modules for JavaScript
 
 ## Overview
 The Azure Billing APIs provide access to your Azure billing information and invoices.
@@ -24,31 +24,12 @@ To use this API, the account admin must opt in via the Azure portal. See [Manage
 Install the Azure Billing npm module 
 
 ```bash
-npm install azure-arm-billing
+npm install @azure/ms-rest-nodeauth
 ```
 ### Example 
  
-This example prints a list of all of your past invoices.
- 
-```javascript 
-const msRestAzure = require('ms-rest-azure');
-const BillingManagement = require('azure-arm-billing');
-
-const subscriptionId = 'your-subscription-id';
-
-msRestAzure
-  .interactiveLogin()
-  .then(credentials => {
-    let client = new BillingManagement(credentials, subscriptionId);
-    return client.invoices.list();
-  })
-  .then(invoices => {
-    console.log('List of invoices:');
-    console.dir(invoices, { depth: null, colors: true });
-  });
-``` 
-
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-billing)
 
 ## Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/cdn.md
+++ b/docs-ref-services/cdn.md
@@ -28,10 +28,8 @@ Install the Azure CDN npm module
 npm install @azure/arm-cdn
 ```
 
-### Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-cdn)
-
 ## Samples
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-cdn)
+
+* For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/cdn.md
+++ b/docs-ref-services/cdn.md
@@ -30,8 +30,8 @@ npm install @azure/arm-cdn
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-cdn)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-cdn)
 
 ## Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/cdn.md
+++ b/docs-ref-services/cdn.md
@@ -1,6 +1,6 @@
 ---
-title: Azure CDN modules for Node.js
-description: Reference for Azure CDN modules for Node.js
+title: Azure CDN modules for JavaScript
+description: Reference for Azure CDN modules for JavaScript
 author: dksimpson
 ms.author: v-deasim
 manager: v-laurab
@@ -12,7 +12,7 @@ ms.devlang: nodejs
 ms.service: CDN
 ---
 
-# Azure CDN modules for Node.js
+# Azure CDN modules for JavaScript
 
 ## Overview
 
@@ -25,27 +25,13 @@ The Azure Content Delivery Network (CDN) offers developers a global solution for
 Install the Azure CDN npm module
 
 ```bash
-npm install azure-arm-cdn
+npm install @azure/arm-cdn
 ```
 
 ### Example
 
-This example lists all of the CDN profiles.
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const cdnManagementClient = require('azure-arm-cdn');
-
-const subscriptionId = 'your-subscription-id';
-
-msRestAzure.interactiveLogin().then(credentials => {
-  const cdnClient = new cdnManagementClient(credentials, subscriptionId);
-  cdnClient.profiles
-    .list()
-    .then(profilesList => console.log('Retrieved profiles list: ', profilesList));
-});
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-cdn)
 
 ## Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/cognitive-services.md
+++ b/docs-ref-services/cognitive-services.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Cognitive Services modules for Node.js
-description: Reference for Azure Cognitive Services modules for Node.js
+title: Azure Cognitive Services modules for JavaScript
+description: Reference for Azure Cognitive Services modules for JavaScript
 author: brapel
 ms.author: v-brapel
 manager: ehansen
@@ -30,7 +30,7 @@ Get the JavaScript module with [npm](https://docs.npmjs.com/getting-started/inst
 npm install azure-cognitiveservices-computervision
 ```
 
-[Learn more](/azure/cognitive-services/computer-vision/home) about the Computer Vision API and get started with the [Computer Vision API JavaScript quickstart](/azure/cognitive-services/computer-vision/quickstarts/javascript).
+[Learn more](/azure/cognitive-services/computer-vision/home) about the Computer Vision API and get started with the [Computer Vision API JavaScript quickstart](/azure/cognitive-services/computer-vision/quickstarts/JavaScript).
 
 ### Content Moderator
 
@@ -56,7 +56,7 @@ Get the JavaScript module with [npm](https://docs.npmjs.com/getting-started/inst
 npm install azure-cognitiveservices-face
 ```
 
-[Learn more](/azure/cognitive-services/face/overview) about the Face API and get started with the [Face API JavaScript quickstart](/azure/cognitive-services/Face/quickstarts/javascript).
+[Learn more](/azure/cognitive-services/face/overview) about the Face API and get started with the [Face API JavaScript quickstart](/azure/cognitive-services/Face/quickstarts/JavaScript).
 
 ## Search modules
 
@@ -72,7 +72,7 @@ Get the JavaScript module with [npm](https://docs.npmjs.com/getting-started/inst
 npm install azure-cognitiveservices-websearch
 ```
 
-[Learn more](/azure/cognitive-services/bing-web-search/overview) about the Bing Web Search API and get started with the [Web Search API Node.js quickstart](/azure/cognitive-services/bing-web-search/quickstarts/nodejs).
+[Learn more](/azure/cognitive-services/bing-web-search/overview) about the Bing Web Search API and get started with the [Web Search API JavaScript quickstart](/azure/cognitive-services/bing-web-search/quickstarts/nodejs).
 
 ### Image search
 
@@ -86,7 +86,7 @@ Get the JavaScript module with [npm](https://docs.npmjs.com/getting-started/inst
 npm install azure-cognitiveservices-imagesearch
 ```
 
-[Learn more](/azure/cognitive-services/bing-image-search/overview) about the Bing Image Search API and get started with the [Image Search API Node.js quickstart](/azure/cognitive-services/bing-image-search/quickstarts/nodejs).
+[Learn more](/azure/cognitive-services/bing-image-search/overview) about the Bing Image Search API and get started with the [Image Search API JavaScript quickstart](/azure/cognitive-services/bing-image-search/quickstarts/nodejs).
 
 
 ### Entity search
@@ -101,7 +101,7 @@ Get the JavaScript module with [npm](https://docs.npmjs.com/getting-started/inst
 npm install azure-cognitiveservices-entitysearch
 ```
 
-[Learn more](/azure/cognitive-services/bing-entities-search/search-the-web) about the Bing Entity Search API and get started with the [Entity Search API Node.js quickstart](/azure/cognitive-services/bing-entities-search/quickstarts/nodejs).
+[Learn more](/azure/cognitive-services/bing-entities-search/search-the-web) about the Bing Entity Search API and get started with the [Entity Search API JavaScript quickstart](/azure/cognitive-services/bing-entities-search/quickstarts/nodejs).
 
 ### Custom search
 
@@ -113,7 +113,7 @@ Get the JavaScript module with [npm](https://docs.npmjs.com/getting-started/inst
 npm install azure-cognitiveservices-customsearch
 ```
 
-[Learn more](/azure/cognitive-services/bing-custom-search/) about the Bing Custom Search service and get started with querying your custom search from your apps with the [Custom Search API Node.js quickstart](/azure/cognitive-services/bing-custom-search/call-endpoint-nodejs).
+[Learn more](/azure/cognitive-services/bing-custom-search/) about the Bing Custom Search service and get started with querying your custom search from your apps with the [Custom Search API JavaScript quickstart](/azure/cognitive-services/bing-custom-search/call-endpoint-nodejs).
 
 ### Video search
 
@@ -127,7 +127,7 @@ Get the JavaScript module with [npm](https://docs.npmjs.com/getting-started/inst
 npm install azure-cognitiveservices-videosearch
 ```
 
-[Learn more](/azure/cognitive-services/bing-video-search/search-the-web) about the Bing Video Search service and get started with the [Video Search API Node.js quickstart](/azure/cognitive-services/bing-video-search/nodejs).
+[Learn more](/azure/cognitive-services/bing-video-search/search-the-web) about the Bing Video Search service and get started with the [Video Search API JavaScript quickstart](/azure/cognitive-services/bing-video-search/nodejs).
 
 
 ### News search
@@ -163,7 +163,7 @@ Get the JavaScript module with [npm](https://docs.npmjs.com/getting-started/inst
 npm install azure-cognitiveservices-textanalytics
 ```
 
-[Learn more](/azure/cognitive-services/text-analytics/overview) about the Text Analytics API and get started with the [Text Analytics API Node.js quickstart](/azure/cognitive-services/text-analytics/quickstarts/nodejs).
+[Learn more](/azure/cognitive-services/text-analytics/overview) about the Text Analytics API and get started with the [Text Analytics API JavaScript quickstart](/azure/cognitive-services/text-analytics/quickstarts/nodejs).
 
 
 ### Spell Check
@@ -178,8 +178,8 @@ Get the JavaScript module with [npm](https://docs.npmjs.com/getting-started/inst
 npm install azure-cognitiveservices-spellcheck
 ```
 
-[Learn more](/azure/cognitive-services/bing-spell-check/proof-text) about the Spell Check API and get started with the [Spell Check API Node.js quickstart](/azure/cognitive-services/bing-spell-check/quickstarts/nodejs).
+[Learn more](/azure/cognitive-services/bing-spell-check/proof-text) about the Spell Check API and get started with the [Spell Check API JavaScript quickstart](/azure/cognitive-services/bing-spell-check/quickstarts/nodejs).
 
 ## Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/cognitive-services.md
+++ b/docs-ref-services/cognitive-services.md
@@ -182,4 +182,4 @@ npm install azure-cognitiveservices-spellcheck
 
 ## Samples
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/cognitive-services.md
+++ b/docs-ref-services/cognitive-services.md
@@ -182,4 +182,4 @@ npm install azure-cognitiveservices-spellcheck
 
 ## Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/commerce.md
+++ b/docs-ref-services/commerce.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Commerce modules for Node.js
-description: Reference for Azure Commerce modules for Node.js
+title: Azure Commerce modules for JavaScript
+description: Reference for Azure Commerce modules for JavaScript
 author: rloutlaw
 ms.author: ROutlaw
 manager: angrobew
@@ -12,7 +12,7 @@ ms.devlang: nodejs
 ms.service: Commerce
 ---
 
-# Azure Commerce modules for Node.js
+# Azure Commerce modules for JavaScript
 
 ## Overview
 
@@ -25,40 +25,13 @@ Use Azure Commerce APIs to pull usage and resource data into your preferred data
 Install the Azure Commerce npm module
 
 ```bash
-npm install azure-arm-commerce
+npm install @azure/arm-commerce
 ```
 
 ### Example
 
-This example retrieves your estimated Azure consumption data for the last month.
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const CommerceManagement = require('azure-arm-commerce');
-
-const endDate = new Date();
-endDate.setUTCHours(0, 0, 0, 0);
-const startDate = new Date();
-startDate.setMonth(startDate.getMonth() - 1);
-startDate.setUTCHours(0, 0, 0, 0);
-
-const subscriptionId = 'your-subscription-id';
-const usageOptions = {
-  showDetails: true,
-  granularity: 'Daily'
-};
-
-msRestAzure
-  .interactiveLogin()
-  .then(credentials => {
-    const client = new CommerceManagement(credentials, subscriptionId);
-    return client.usageAggregates.list(startDate, endDate, usageOptions);
-  })
-  .then(usage => {
-    console.dir(usage, { depth: null, colors: true });
-  });
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-commerce)
 
 ## Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/commerce.md
+++ b/docs-ref-services/commerce.md
@@ -30,8 +30,8 @@ npm install @azure/arm-commerce
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-commerce)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-commerce)
 
 ## Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/commerce.md
+++ b/docs-ref-services/commerce.md
@@ -28,10 +28,8 @@ Install the Azure Commerce npm module
 npm install @azure/arm-commerce
 ```
 
-### Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-commerce)
-
 ## Samples
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-commerce)
+
+* For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/container-registry.md
+++ b/docs-ref-services/container-registry.md
@@ -28,8 +28,8 @@ npm install @azure/arm-containerregistry
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-containerregistry)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-containerregistry)
 
 ## Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/container-registry.md
+++ b/docs-ref-services/container-registry.md
@@ -26,10 +26,8 @@ Install the Azure container registry npm module
 npm install @azure/arm-containerregistry
 ```
 
-### Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-containerregistry)
-
 ## Samples
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-containerregistry)
+
+* For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/container-registry.md
+++ b/docs-ref-services/container-registry.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Container Registry modules for Node.js
-description: Reference for Azure Container Registry Modules for Node.js
+title: Azure Container Registry modules for JavaScript
+description: Reference for Azure Container Registry Modules for JavaScript
 author: mmacy
 ms.author: marsma
 manager: jeconnoc
@@ -12,7 +12,7 @@ ms.devlang: nodejs
 ms.service: Container Registry
 ---
 
-# Azure Container Registry modules for Node.js
+# Azure Container Registry modules for JavaScript
 
 Azure Container Registry is a managed Docker registry service based on the open-source Docker Registry 2.0. Create and maintain Azure container registries to store and manage your private Docker container images. Use container registries in Azure with your existing container development and deployment pipelines, and draw on the body of Docker community expertise.
 
@@ -23,34 +23,13 @@ Azure Container Registry is a managed Docker registry service based on the open-
 Install the Azure container registry npm module
 
 ```bash
-npm install azure-arm-containerregistry
+npm install @azure/arm-containerregistry
 ```
 
 ### Example
 
-This example gets a list of the available containers.
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const ContainerRegistryManagement = require('azure-arm-containerregistry');
-
-const subscriptionId = 'your-subscription-id';
-
-msRestAzure
-  .interactiveLogin()
-  .then(credentials => {
-    const manager = new ContainerRegistryManagement(
-      credentials,
-      subscriptionId
-    );
-    return manager.registries.list();
-  })
-  .then(registries => {
-    console.log('List of registries:');
-    console.dir(registries, { depth: null, colors: true });
-  });
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-containerregistry)
 
 ## Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/container-service.md
+++ b/docs-ref-services/container-service.md
@@ -27,7 +27,7 @@ npm install @azure/arm-containerservice
 
 ## How to use
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-containerservice)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-containerservice)
 
 ## Related projects
 

--- a/docs-ref-services/container-service.md
+++ b/docs-ref-services/container-service.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Container Service modules for Node.js
-description: Reference for Azure Container Service Modules for Node.js
+title: Azure Container Service modules for JavaScript
+description: Reference for Azure Container Service Modules for JavaScript
 author: mmacy
 ms.author: marsma
 manager: jeconnoc
@@ -12,9 +12,9 @@ ms.devlang: nodejs
 ms.service: Container Service
 ---
 
-# Microsoft Azure SDK for Node.js - ContainerServiceClient
-This project provides a Node.js package for accessing Azure. Right now it supports:
-- **Node.js version 6.x.x or higher**
+# Microsoft Azure SDK for JavaScript - ContainerServiceClient
+This project provides a JavaScript package for accessing Azure. Right now it supports:
+- **JavaScript version 6.x.x or higher**
 
 ## Features
 
@@ -22,29 +22,13 @@ This project provides a Node.js package for accessing Azure. Right now it suppor
 ## How to Install
 
 ```bash
-npm install azure-arm-containerservice
+npm install @azure/arm-containerservice
 ```
 
 ## How to use
 
-### Authentication, client creation and list containerServices as an example.
-
-```javascript
-const msRestAzure = require("ms-rest-azure");
-const ContainerServiceClient = require("azure-arm-containerservice");
-msRestAzure.interactiveLogin().then((creds) => {
-    const subscriptionId = "<Subscription_Id>";
-    const client = new ContainerServiceClient(creds, subscriptionId);
-    return client.containerServices.list().then((result) => {
-      console.log("The result is:");
-      console.log(result);
-    });
-}).catch((err) => {
-  console.log('An error ocurred:');
-  console.dir(err, {depth: null, colors: true});
-});
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-containerservice)
 
 ## Related projects
 
-- [Microsoft Azure SDK for Node.js](https://github.com/Azure/azure-sdk-for-node)
+- [Microsoft Azure SDK for JavaScript](https://github.com/Azure/azure-sdk-for-node)

--- a/docs-ref-services/container-service.md
+++ b/docs-ref-services/container-service.md
@@ -25,10 +25,8 @@ This project provides a JavaScript package for accessing Azure. Right now it sup
 npm install @azure/arm-containerservice
 ```
 
-## How to use
+## Samples
 
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-containerservice)
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-containerservice)
 
-## Related projects
-
-- [Microsoft Azure SDK for JavaScript](https://github.com/Azure/azure-sdk-for-node)
+* For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/cosmos-db.md
+++ b/docs-ref-services/cosmos-db.md
@@ -27,11 +27,11 @@ npm install @azure/arm-cosmosdb
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-cosmosdb)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-cosmosdb)
 
 ## Samples
 
 * [Developing a JavaScript app using Azure Cosmos DB](https://azure.microsoft.com/resources/samples/azure-cosmos-db-documentdb-nodejs-getting-started/)
 * [Developing a JavaScript app using Azure Cosmos DB - Gremlin](https://azure.microsoft.com/resources/samples/azure-cosmos-db-graph-nodejs-getting-started/)
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/cosmos-db.md
+++ b/docs-ref-services/cosmos-db.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Cosmos DB Modules for Node.js
-description: Reference for Azure Cosmos DB modules for Node.js
+title: Azure Cosmos DB Modules for JavaScript
+description: Reference for Azure Cosmos DB modules for JavaScript
 author: SnehaGunda
 ms.author: sngun
 ms.date: 03/20/2018
@@ -9,7 +9,7 @@ ms.devlang: nodejs
 ms.service: cosmos-db
 ---
 
-# Azure Cosmos DB Modules for Node.js
+# Azure Cosmos DB Modules for JavaScript
 
 Azure Cosmos DB is Microsoft's globally distributed, multi-model database. Azure Cosmos DB enables you to elastically and independently scale throughput and storage across any number of Azure's geographic regions. It offers throughput, latency, availability, and consistency guarantees with comprehensive service level agreements (SLAs), something no other database service can offer.
 
@@ -22,30 +22,16 @@ Azure Cosmos DB contains a write optimized, resource governed, schema-agnostic d
 Install the Azure Cosmos DB npm module.
 
 ```bash
-npm install azure-arm-documentdb
+npm install @azure/arm-cosmosdb
 ```
 
 ### Example
 
-This example lists all Azure Cosmos DB accounts.
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const documentDBManagementClient = require('azure-arm-documentdb');
-
-const subscriptionId = 'your-subscription-id';
-
-msRestAzure.interactiveLogin().then(credentials => {
-  const documentDbClient = new documentDBManagementClient(credentials, subscriptionId);
-  documentDbClient.databaseAccounts
-    .list()
-    .then(databaseAccounts => console.log('Retrieved database accounts: ', databaseAccounts));
-});
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-cosmosdb)
 
 ## Samples
 
-* [Developing a Node.js app using Azure Cosmos DB](https://azure.microsoft.com/resources/samples/azure-cosmos-db-documentdb-nodejs-getting-started/)
-* [Developing a Node.js app using Azure Cosmos DB - Gremlin](https://azure.microsoft.com/resources/samples/azure-cosmos-db-graph-nodejs-getting-started/)
+* [Developing a JavaScript app using Azure Cosmos DB](https://azure.microsoft.com/resources/samples/azure-cosmos-db-documentdb-nodejs-getting-started/)
+* [Developing a JavaScript app using Azure Cosmos DB - Gremlin](https://azure.microsoft.com/resources/samples/azure-cosmos-db-graph-nodejs-getting-started/)
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/cosmos-db.md
+++ b/docs-ref-services/cosmos-db.md
@@ -25,13 +25,10 @@ Install the Azure Cosmos DB npm module.
 npm install @azure/arm-cosmosdb
 ```
 
-### Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-cosmosdb)
-
 ## Samples
 
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-cosmosdb)
 * [Developing a JavaScript app using Azure Cosmos DB](https://azure.microsoft.com/resources/samples/azure-cosmos-db-documentdb-nodejs-getting-started/)
 * [Developing a JavaScript app using Azure Cosmos DB - Gremlin](https://azure.microsoft.com/resources/samples/azure-cosmos-db-graph-nodejs-getting-started/)
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/data-lake-analytics.md
+++ b/docs-ref-services/data-lake-analytics.md
@@ -28,8 +28,8 @@ npm install azure-arm-datalake-analytics
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/azure-arm-datalake-analytics)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/azure-arm-datalake-analytics)
 
 ## Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/data-lake-analytics.md
+++ b/docs-ref-services/data-lake-analytics.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Data Lake Analytics modules for JavaScript
-description: Reference for Azure Data Lake Analytics modules for JavaScript
+title: Azure Data Lake Analytics modules for Node.JS
+description: Reference for Azure Data Lake Analytics modules for Node.JS
 author: craigshoemaker
 ms.author: cshoe
 manager: routlaw
@@ -12,7 +12,7 @@ ms.devlang: nodejs
 ms.service: Data Lake Analytics
 ---
 
-# Azure Data Lake Analytics modules for JavaScript
+# Azure Data Lake Analytics modules for Node.JS
 
 Azure Data Lake Analytics is an on-demand analytics job service to simplify big data analytics. You can focus on writing, running, and managing jobs rather than on operating distributed infrastructure. Instead of deploying, configuring, and tuning hardware, you write queries to transform your data and extract valuable insights. The analytics service can handle jobs of any scale instantly by setting the dial for how much power you need. You only pay for your job when it is running, making it cost-effective. The analytics service supports Azure Active Directory letting you manage access and roles, integrated with your on-premises identity system. It also includes U-SQL, a language that unifies the benefits of SQL with the expressive power of user code. U-SQL’s scalable distributed runtime enables you to efficiently analyze data in the store and across SQL Servers in Azure, Azure SQL Database, and Azure SQL Data Warehouse.
 
@@ -20,16 +20,14 @@ Azure Data Lake Analytics is an on-demand analytics job service to simplify big 
 
 ### Install the npm module
 
-Use npm to install the Azure Data Lake Analytics modules for JavaScript
+Use npm to install the Azure Data Lake Analytics modules for Node.JS
 
 ```bash
 npm install azure-arm-datalake-analytics
 ```
 
-### Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/azure-arm-datalake-analytics)
-
 ## Samples
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+* Examples for using this module in Node.js can be found in the [README for the module](https://www.npmjs.com/package/azure-arm-datalake-analytics)
+
+* For more code samples that use various Azure packages, explore the [Node.JS samples](https://docs.microsoft.com/samples/browse/?languages=nodejs).

--- a/docs-ref-services/data-lake-analytics.md
+++ b/docs-ref-services/data-lake-analytics.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Data Lake Analytics modules for Node.js
-description: Reference for Azure Data Lake Analytics modules for Node.js
+title: Azure Data Lake Analytics modules for JavaScript
+description: Reference for Azure Data Lake Analytics modules for JavaScript
 author: craigshoemaker
 ms.author: cshoe
 manager: routlaw
@@ -12,7 +12,7 @@ ms.devlang: nodejs
 ms.service: Data Lake Analytics
 ---
 
-# Azure Data Lake Analytics modules for Node.js
+# Azure Data Lake Analytics modules for JavaScript
 
 Azure Data Lake Analytics is an on-demand analytics job service to simplify big data analytics. You can focus on writing, running, and managing jobs rather than on operating distributed infrastructure. Instead of deploying, configuring, and tuning hardware, you write queries to transform your data and extract valuable insights. The analytics service can handle jobs of any scale instantly by setting the dial for how much power you need. You only pay for your job when it is running, making it cost-effective. The analytics service supports Azure Active Directory letting you manage access and roles, integrated with your on-premises identity system. It also includes U-SQL, a language that unifies the benefits of SQL with the expressive power of user code. U-SQL’s scalable distributed runtime enables you to efficiently analyze data in the store and across SQL Servers in Azure, Azure SQL Database, and Azure SQL Data Warehouse.
 
@@ -20,7 +20,7 @@ Azure Data Lake Analytics is an on-demand analytics job service to simplify big 
 
 ### Install the npm module
 
-Use npm to install the Azure Data Lake Analytics modules for Node.js
+Use npm to install the Azure Data Lake Analytics modules for JavaScript
 
 ```bash
 npm install azure-arm-datalake-analytics
@@ -28,25 +28,8 @@ npm install azure-arm-datalake-analytics
 
 ### Example
 
-This example lists all of the analytics accounts for a given subscription.
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const adlsManagement = require('azure-arm-datalake-analytics');
-
-const subscriptionId = 'your-subscription-id';
-
-msRestAzure.interactiveLogin().then(credentials => {
-  const accountClient = new adlsManagement.DataLakeAnalyticsAccountClient(
-    credentials,
-    subscriptionId
-  );
-  accountClient.account.list().then(result => {
-    console.log(result);
-  });
-});
-```
+Example can be found here: [Example](https://www.npmjs.com/package/azure-arm-datalake-analytics)
 
 ## Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/data-lake-store.md
+++ b/docs-ref-services/data-lake-store.md
@@ -12,7 +12,7 @@ ms.devlang: nodejs
 ms.service: Data Lake Store
 ---
 
-# Azure Data Lake Store modules for JavaScript
+# Azure Data Lake Store modules for Node.JS
 
 Azure Data Lake Store is an enterprise-wide hyper-scale repository for big data analytic workloads. Azure Data Lake enables you to capture data of any size, type, and ingestion speed in one single place for operational and exploratory analytics.
 
@@ -20,16 +20,14 @@ Azure Data Lake Store is an enterprise-wide hyper-scale repository for big data 
 
 ### Install the npm module
 
-Use npm to install the Azure Data Lake Store modules for JavaScript
+Use npm to install the Azure Data Lake Store modules for Node.JS
 
 ```bash
 npm install azure-arm-datalake-store
 ```
 
-### Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/azure-arm-datalake-store)
-
 ## Samples
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+* Examples for using this module in Node.js can be found in the [README for the module](https://www.npmjs.com/package/azure-arm-datalake-store)
+
+* For more code samples that use various Azure packages, explore the [Node.JS samples](https://docs.microsoft.com/samples/browse/?languages=nodejs).

--- a/docs-ref-services/data-lake-store.md
+++ b/docs-ref-services/data-lake-store.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Data Lake Store modules for Node.js
-description: Reference for Azure Data Lake Store modules for Node.js
+title: Azure Data Lake Store modules for JavaScript
+description: Reference for Azure Data Lake Store modules for JavaScript
 author: craigshoemaker
 ms.author: cshoe
 manager: routlaw
@@ -12,7 +12,7 @@ ms.devlang: nodejs
 ms.service: Data Lake Store
 ---
 
-# Azure Data Lake Store modules for Node.js
+# Azure Data Lake Store modules for JavaScript
 
 Azure Data Lake Store is an enterprise-wide hyper-scale repository for big data analytic workloads. Azure Data Lake enables you to capture data of any size, type, and ingestion speed in one single place for operational and exploratory analytics.
 
@@ -20,7 +20,7 @@ Azure Data Lake Store is an enterprise-wide hyper-scale repository for big data 
 
 ### Install the npm module
 
-Use npm to install the Azure Data Lake Store modules for Node.js
+Use npm to install the Azure Data Lake Store modules for JavaScript
 
 ```bash
 npm install azure-arm-datalake-store
@@ -28,25 +28,8 @@ npm install azure-arm-datalake-store
 
 ### Example
 
-This example lists all Data Lake Store accounts within a given Azure subscription
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const adlsManagement = require('azure-arm-datalake-store');
-
-const subscriptionId = 'your-subscription-id';
-
-msRestAzure.interactiveLogin().then(credentials => {
-  const accountClient = new adlsManagement.DataLakeStoreAccountClient(
-    credentials,
-    subscriptionId
-  );
-  accountClient.account.list().then(result => {
-    console.log(result);
-  });
-});
-```
+Example can be found here: [Example](https://www.npmjs.com/package/azure-arm-datalake-store)
 
 ## Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/data-lake-store.md
+++ b/docs-ref-services/data-lake-store.md
@@ -28,8 +28,8 @@ npm install azure-arm-datalake-store
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/azure-arm-datalake-store)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/azure-arm-datalake-store)
 
 ## Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/devtest-labs.md
+++ b/docs-ref-services/devtest-labs.md
@@ -28,8 +28,8 @@ npm install @azure/arm-devtestlabs
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-devtestlabs)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-devtestlabs)
 
 ## Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/devtest-labs.md
+++ b/docs-ref-services/devtest-labs.md
@@ -1,6 +1,6 @@
 ---
-title: Azure DevTest Labs Modules for Node.js
-description: Reference for Azure DevTest Labs modules for Node.js
+title: Azure DevTest Labs Modules for JavaScript
+description: Reference for Azure DevTest Labs modules for JavaScript
 author: craigcaseyMSFT
 ms.author: v-craic
 manager: v-laurab
@@ -12,7 +12,7 @@ ms.devlang: nodejs
 ms.service: DevTest Labs
 ---
 
-# Azure DevTest Labs modules for Node.js
+# Azure DevTest Labs modules for JavaScript
 
 Azure DevTest Labs is a service that helps developers and testers quickly create environments in Azure while minimizing waste and controlling cost. You can test the latest version of your application by quickly provisioning Windows and Linux environments using reusable templates and artifacts. Easily integrate your deployment pipeline with DevTest Labs to provision on-demand environments. Scale up your load testing by provisioning multiple test agents, and create pre-provisioned environments for training and demos.
 
@@ -23,33 +23,13 @@ Azure DevTest Labs is a service that helps developers and testers quickly create
 Install the Azure DevTest Labs npm module
 
 ```bash
-npm install azure-arm-devtestlabs
+npm install @azure/arm-devtestlabs
 ```
 
 ### Example
 
-This example gets and prints the details of a lab.
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const DevTestLabsClient = require('azure-arm-devtestlabs');
-
-const subscriptionId = 'your-subscription-id';
-const resourceGroupName = 'your-resource-group-name';
-const labName = 'your-lab-name';
-
-msRestAzure
-  .interactiveLogin()
-  .then(credentials => {
-    const client = new DevTestLabsClient(credentials, subscriptionId);
-    return client.labOperations.getResource(resourceGroupName, labName);
-  })
-  .then(lab => {
-    console.log('Details of lab:');
-    console.dir(lab, { depth: null, colors: true });
-  });
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-devtestlabs)
 
 ## Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/devtest-labs.md
+++ b/docs-ref-services/devtest-labs.md
@@ -26,10 +26,8 @@ Install the Azure DevTest Labs npm module
 npm install @azure/arm-devtestlabs
 ```
 
-### Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-devtestlabs)
-
 ## Samples
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-devtestlabs)
+
+* For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/dns.md
+++ b/docs-ref-services/dns.md
@@ -26,10 +26,8 @@ Install the Azure DNS npm module
 npm install @azure/arm-dns
 ```
 
-### Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-dns)
-
 ## Samples
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-dns)
+
+* For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/dns.md
+++ b/docs-ref-services/dns.md
@@ -1,6 +1,6 @@
 ---
-title: Azure DNS modules for Node.js
-description: Reference for Azure DNS modules for Node.js
+title: Azure DNS modules for JavaScript
+description: Reference for Azure DNS modules for JavaScript
 author: KumudD
 ms.author: kumud
 manager: jeconnoc
@@ -12,7 +12,7 @@ ms.devlang: nodejs
 ms.service: DNS
 ---
 
-# Azure DNS modules for Node.js
+# Azure DNS modules for JavaScript
 
 Use Azure DNS to host your Domain Name System (DNS) domains in Azure. Manage your DNS records using the same credentials and billing and support contract as your other Azure services. Seamlessly integrate Azure-based services with corresponding DNS updates and streamline your end-to-end deployment process.
 
@@ -23,29 +23,13 @@ Use Azure DNS to host your Domain Name System (DNS) domains in Azure. Manage you
 Install the Azure DNS npm module
 
 ```bash
-npm install azure-arm-dns
+npm install @azure/arm-dns
 ```
 
 ### Example
 
-This example lists the DNS Management zones.
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const DNSManagement = require('azure-arm-dns');
-
-const subscriptionId = 'your-subscription-id';
-
-msRestAzure
-  .interactiveLogin()
-  .then(credentials => {
-    const client = new DNSManagement(credentials, subscriptionId);
-    return client.zones.list();
-  })
-  .then(zones => console.dir(zones, { depth: null, colors: true }))
-  .catch(err => console.log(err));
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-dns)
 
 ## Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/dns.md
+++ b/docs-ref-services/dns.md
@@ -28,8 +28,8 @@ npm install @azure/arm-dns
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-dns)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-dns)
 
 ## Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/event-hub.md
+++ b/docs-ref-services/event-hub.md
@@ -26,10 +26,8 @@ Use npm to install the Azure Event Hub modules for JavaScript
 npm install @azure/arm-eventhub
 ```
 
-### Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-eventhub)
-
 ## Samples
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-eventhub)
+
+* For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/event-hub.md
+++ b/docs-ref-services/event-hub.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Event Hub modules for Node.js
-description: Reference for Azure Event Hub modules for Node.js
+title: Azure Event Hub modules for JavaScript
+description: Reference for Azure Event Hub modules for JavaScript
 author: sethmanheim
 ms.author: sethm
 manager: timlt
@@ -12,7 +12,7 @@ ms.devlang: nodejs
 ms.service: Event Hub
 ---
 
-# Azure Event Hub modules for Node.js
+# Azure Event Hub modules for JavaScript
 
 Azure Event Hubs is a highly scalable data streaming platform and event ingestion service capable of receiving and processing millions of events per second. Event Hubs can process and store events, data, or telemetry produced by distributed software and devices. Data sent to an event hub can be transformed and stored using any real-time analytics provider or batching/storage adapters. With the ability to provide publish-subscribe capabilities with low latency and at massive scale, Event Hubs serves as the "on ramp" for Big Data.
 
@@ -20,35 +20,16 @@ Azure Event Hubs is a highly scalable data streaming platform and event ingestio
 
 ### Install the npm module 
 
-Use npm to install the Azure Event Hub modules for Node.js
+Use npm to install the Azure Event Hub modules for JavaScript
 
 ```bash
-npm install azure-arm-eventhub
+npm install @azure/arm-eventhub
 ```
 
 ### Example
 
-This example retrieves information about an existing event hub.
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const EventHubManagement = require('azure-arm-eventhub');
-
-const resourceGroupName = 'testRG';
-const namespaceName = 'testNS';
-const eventHubName = 'testEH';
-const subscriptionId = 'your-subscription-id';
-
-msRestAzure
-  .interactiveLogin()
-  .then(credentials => {
-    const client = new EventHubManagement(credentials, subscriptionId);
-    return client.eventHubs.get(resourceGroupName, namespaceName, eventHubName);
-  })
-  .then(zones => console.dir(zones, { depth: null, colors: true }))
-  .catch(err => console.log(err));
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-eventhub)
 
 ## Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/event-hub.md
+++ b/docs-ref-services/event-hub.md
@@ -28,8 +28,8 @@ npm install @azure/arm-eventhub
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-eventhub)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-eventhub)
 
 ## Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/eventgrid.md
+++ b/docs-ref-services/eventgrid.md
@@ -111,7 +111,7 @@ Create, update, or delete Event Grid instances, topics, and subscriptions with t
 npm install @azure/arm-eventgrid
 ```
 
-### Example code
+### Samples
 
 Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-eventgrid)
 

--- a/docs-ref-services/eventgrid.md
+++ b/docs-ref-services/eventgrid.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Event Grid libraries for Node.js
-description: Reference for Azure Event Grid libraries for Node.js
+title: Azure Event Grid libraries for JavaScript
+description: Reference for Azure Event Grid libraries for JavaScript
 author: rloutlaw 
 ms.author: routlaw    
 manager: angerobe
@@ -13,7 +13,7 @@ ms.service: event-grid
 ms.custom: devcenter
 ---
 
-# Azure Event Grid libraries for Node.js
+# Azure Event Grid libraries for JavaScript
 
 Build event-driven applications that listen and react to events from Azure services and custom sources using simple HTTP-based event handling with Azure Event Grid.
 
@@ -40,7 +40,7 @@ endpoint=$(az eventgrid topic show --name <topic_name> -g gridResourceGroup --qu
 key=$(az eventgrid topic key list --name <topic_name> -g gridResourceGroup --query "key1" --output tsv)
 ```
 
-```javascript
+```JavaScript
 var EventGridClient = require("azure-eventgrid");
 var msRestAzure = require('ms-rest-azure');
 var uuid = require('uuid').v4;
@@ -70,7 +70,7 @@ return EGClient.publishEvents(topicHostName, events).then((result) => {
 
 This sample shows how to handle an event from Azure Storage:
 
-```javascript
+```JavaScript
 var http = require('http');
 
 module.exports = function (context, req) {
@@ -99,7 +99,7 @@ module.exports = function (context, req) {
 ```
 
 > [!div class="nextstepaction"]
-> [Explore the client APIs](/javascript/api/overview/azure/eventgrid/client)
+> [Explore the client APIs](/JavaScript/api/overview/azure/eventgrid/client)
 
 ## Management SDK
 
@@ -108,32 +108,15 @@ Create, update, or delete Event Grid instances, topics, and subscriptions with t
 ### Installation
 
 ```
-npm install azure-arm-eventgrid
+npm install @azure/arm-eventgrid
 ```
 
 ### Example code
 
-The following code creates an Event Grid topic `topic1` and returns the access keys associated with the newly created topic.
-
-```javascript
-var msRestAzure = require('ms-rest-azure');
-var EventGridManagementClient = require("azure-arm-eventgrid");
-
-msRestAzure.interactiveLogin(function(err, credentials) {
-    // Created the management client
-    let EGMClient = new EventGridManagementClient(credentials, 'your-subscription-id');
-    let topicResponse;
-    // created an enventgrid topic
-    return EGMClient.topics.createOrUpdate('resourceGroup', 'topic1', { location: 'westus' }).then((topicResponse) => {
-        return Promise.resolve(console.log('Created topic ', topicResponse));
-    }).then(() => {
-        // listed the access keys
-        return EGMClient.topics.listSharedAccessKeys('resourceGroup', 'topic1')}
-)};
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-eventgrid)
 
 > [!div class="nextstepaction"]
-> [Explore the management APIs](/javascript/api/overview/azure/eventgrid/management)
+> [Explore the management APIs](/https://www.npmjs.com/package/@azure/arm-eventgrid)
 
 ## Learn more
 

--- a/docs-ref-services/eventgrid.md
+++ b/docs-ref-services/eventgrid.md
@@ -113,7 +113,7 @@ npm install @azure/arm-eventgrid
 
 ### Example code
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-eventgrid)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-eventgrid)
 
 > [!div class="nextstepaction"]
 > [Explore the management APIs](/https://www.npmjs.com/package/@azure/arm-eventgrid)

--- a/docs-ref-services/hdinsight.md
+++ b/docs-ref-services/hdinsight.md
@@ -1,6 +1,6 @@
 ---
-title: Azure HDInsight Modules for Node.js
-description: Reference for Azure HDInsight Modules for Node.js
+title: Azure HDInsight Modules for JavaScript
+description: Reference for Azure HDInsight Modules for JavaScript
 ms.service: hdinsight
 author: jasonwhowell
 ms.author: jasonh
@@ -10,7 +10,7 @@ ms.devlang: nodejs
 ms.date: 07/18/2017
 ---
 
-# Azure HDInsight Modules for Node.js
+# Azure HDInsight Modules for JavaScript
 
 Azure HDInsight is a cloud distribution of the Hadoop components from the Hortonworks Data Platform (HDP). Apache Hadoop was the original open-source framework for distributed processing and analysis of big data sets on clusters of computers.
 
@@ -28,39 +28,20 @@ The Hadoop technology stack includes related software and utilities, including A
 
 ### Install the npm modules
 
-Use npm to install the Azure HDInsight modules for Node.js
+Use npm to install the Azure HDInsight modules for JavaScript
 
 ```bash
 npm install azure-arm-hdinsight
 ```
 
 ```bash
-azure-arm-hdinsight-jobs
+npm install @azure/arm-hdinsight
 ```
 
 ### Example 
 
-This example creates an HD Insight client and then lists all of the available clusters. 
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const HDInsightManagementClient = require('azure-arm-hdinsight');
-
-const subscriptionId = 'my-subscription-id';
-
-msRestAzure.interactiveLogin().then(credentials => {
-    const client = HDInsightManagementClient.createHDInsightManagementClient(
-        credentials
-    );
-
-    credentials.subscriptionId = subscriptionId;
-
-    client.clusters.list((err, result) => {
-        console.log(result);
-    });
-});
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-hdinsight)
 
 ## Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/hdinsight.md
+++ b/docs-ref-services/hdinsight.md
@@ -40,8 +40,8 @@ npm install @azure/arm-hdinsight
 
 ### Example 
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-hdinsight)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-hdinsight)
 
 ## Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/hdinsight.md
+++ b/docs-ref-services/hdinsight.md
@@ -44,4 +44,4 @@ Examples for using this module in Node.js as well as browser applications can be
 
 ## Samples
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/intune.md
+++ b/docs-ref-services/intune.md
@@ -1,3 +1,3 @@
 ---
-redirect_url: https://docs.microsoft.com/nodejs/azure
+redirect_url: https://docs.microsoft.com/en-us/azure/javascript/?view=azure-node-latest
 ---

--- a/docs-ref-services/iot-hub.md
+++ b/docs-ref-services/iot-hub.md
@@ -34,13 +34,10 @@ Install the Azure IoT Hub npm module
 npm install @azure/arm-iothub
 ```
 
-### Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-iothub)
-
 ## Samples
 
+- Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-iothub)
 - [Get started with the Raspberry Pi Azure IoT Starter Kit](https://azure.microsoft.com/resources/samples/iot-remote-monitoring-node-raspberrypi-getstartedkit/)
 - [Tweet vibration anomalies detected by Azure IoT services on data from an Intel Edison running JavaScript](https://azure.microsoft.com/resources/samples/iot-hub-nodejs-intel-edison-vibration-anomaly-detection/)
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/iot-hub.md
+++ b/docs-ref-services/iot-hub.md
@@ -36,11 +36,11 @@ npm install @azure/arm-iothub
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-iothub)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-iothub)
 
 ## Samples
 
 - [Get started with the Raspberry Pi Azure IoT Starter Kit](https://azure.microsoft.com/resources/samples/iot-remote-monitoring-node-raspberrypi-getstartedkit/)
 - [Tweet vibration anomalies detected by Azure IoT services on data from an Intel Edison running JavaScript](https://azure.microsoft.com/resources/samples/iot-hub-nodejs-intel-edison-vibration-anomaly-detection/)
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/iot-hub.md
+++ b/docs-ref-services/iot-hub.md
@@ -1,6 +1,6 @@
 ---
-title: Azure IoT Hub modules for Node.js
-description: Reference for Azure IoT Hub modules for Node.js
+title: Azure IoT Hub modules for JavaScript
+description: Reference for Azure IoT Hub modules for JavaScript
 author: dominicbetts
 ms.author: dobett
 manager: timlt
@@ -12,7 +12,7 @@ ms.devlang: nodejs
 ms.service: IoT Hub
 ---
 
-# Azure IoT Hub modules for Node.js
+# Azure IoT Hub modules for JavaScript
 
 Azure IoT Hub is a fully managed service that enables reliable and secure bidirectional communications between millions of IoT devices and a solution back end. Azure IoT Hub:
 - Provides multiple device-to-cloud and cloud-to-device communication options, including one-way messaging, file transfer, and request-reply methods.
@@ -22,7 +22,7 @@ Azure IoT Hub is a fully managed service that enables reliable and secure bidire
 - Provides extensive monitoring for device connectivity and device identity management events.
 - Includes device libraries for the most popular languages and platforms.
 
-Use npm to install the Azure IoT Hub modules for Node.js
+Use npm to install the Azure IoT Hub modules for JavaScript
 
 ## Management Package
 
@@ -31,74 +31,16 @@ Use npm to install the Azure IoT Hub modules for Node.js
 Install the Azure IoT Hub npm module
 
 ```bash
-npm install azure-arm-iothub
+npm install @azure/arm-iothub
 ```
 
 ### Example
 
-This example creates and names an IoT hub.
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const IoTHubClient = require('azure-arm-iothub');
-
-const subscriptionId = 'your-subscription-id';
-const resourceGroup = 'your-resource-group';
-const hubName = 'your-hub';
-const location = 'East US';
-
-// Describe the IoT hub you want to create
-const hubDescription = {
-  name: hubName,
-  location: location,
-  subscriptionid: subscriptionId,
-  resourcegroup: resourceGroup,
-  sku: { name: 'S1', capacity: 2 },
-  properties: {
-    enableFileUploadNotifications: false,
-    ipFilterRules: [{ filterName: 'ipfilterrule', action: 'accept', ipMask: '0.0.0.0/0' }],
-    operationsMonitoringProperties: {
-      events: {
-        C2DCommands: 'Error',
-        DeviceTelemetry: 'Error',
-        DeviceIdentityOperations: 'Error',
-        Connections: 'Error, Information'
-      }
-    },
-    features: 'None'
-  }
-};
-
-msRestAzure.interactiveLogin().then(credentials => {
-  const client = new IoTHubClient(credentials, subscriptionId);
-
-  client.iotHubResource
-    .createOrUpdate(resourceGroup, hubName, hubDescription)
-    .then(hubDescriptionResult => console.log(hubDescriptionResult))
-    .catch(err => console.error(err));
-});
-```
-
-This example gets the existing IoT hub, by name.
-
-```javascript
-const subscriptionId = 'your-subscription-id';
-const resourceGroup = 'your-resource-group';
-const hubName = 'your-hub';
-
-msRestAzure.interactiveLogin().then(credentials => {
-  const client = new IoTHubClient(credentials, subscriptionId);
-
-  client.iotHubResource
-    .get(resourceGroup, hubName)
-    .then(hubDescriptionResult => console.log(hubDescriptionResult))
-    .catch(err => console.error(err));
-});
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-iothub)
 
 ## Samples
 
 - [Get started with the Raspberry Pi Azure IoT Starter Kit](https://azure.microsoft.com/resources/samples/iot-remote-monitoring-node-raspberrypi-getstartedkit/)
-- [Tweet vibration anomalies detected by Azure IoT services on data from an Intel Edison running Node.js](https://azure.microsoft.com/resources/samples/iot-hub-nodejs-intel-edison-vibration-anomaly-detection/)
+- [Tweet vibration anomalies detected by Azure IoT services on data from an Intel Edison running JavaScript](https://azure.microsoft.com/resources/samples/iot-hub-nodejs-intel-edison-vibration-anomaly-detection/)
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/key-vault.md
+++ b/docs-ref-services/key-vault.md
@@ -30,12 +30,11 @@ npm install @azure/arm-keyvault
 
 ### Example
 
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-keyvault)
 
 ## Samples
-
+- Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-keyvault)
 - [Getting started with Key Vault in JavaScript](https://azure.microsoft.com/resources/samples/key-vault-node-getting-started/)
 - [Manage Azure resources and resource groups with JavaScript](https://azure.microsoft.com/resources/samples/resource-manager-node-resources-and-groups/) 
 - [Integrating Azure AD into a NodeJS web application](https://azure.microsoft.com/resources/samples/active-directory-node-webapp-openidconnect/) 
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/key-vault.md
+++ b/docs-ref-services/key-vault.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Key Vault modules for Node.js
-description: Reference for Azure Key Vault modules for Node.js
+title: Azure Key Vault modules for JavaScript
+description: Reference for Azure Key Vault modules for JavaScript
 author: barclayn
 ms.author: barclayn
 manager: mbaldwin
@@ -12,7 +12,7 @@ ms.devlang: nodejs
 ms.service: Key Vault
 ---
 
-# Azure Key Vault modules for Node.js
+# Azure Key Vault modules for JavaScript
 
 Azure Key Vault helps safeguard cryptographic keys and secrets used by cloud applications and services. By using Key Vault, you can encrypt keys and secrets (such as authentication keys, storage account keys, data encryption keys, .PFX files, and passwords) by using keys that are protected by hardware security modules (HSMs). For added assurance, you can import or generate keys in HSMs. If you choose to do this, Microsoft processes your keys in FIPS 140-2 Level 2 validated HSMs (hardware and firmware).
 
@@ -25,56 +25,17 @@ Key Vault streamlines the key management process and enables you to maintain con
 Install the Azure Key Vault npm module
 
 ```bash
-npm install azure-arm-keyvault
+npm install @azure/arm-keyvault
 ```
 
 ### Example
 
-This example creates a new Key Vault service in Azure.
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const KeyVaultManagementClient = require('azure-arm-keyvault');
-
-const subscriptionId = 'your-subscription-id';
-const resourceGroup = 'your-resource-group';
-const vaultName = 'your-new-vault';
-const tenantGUID = 'your-tenant-guid';
-
-// Interactive Login
-let client;
-msRestAzure
-  .interactiveLogin()
-  .then(credentials => {
-    client = new KeyVaultManagementClient(credentials, subscriptionId);
-    return client.vaults.list();
-  })
-  .then(vaults => {
-    console.dir(vaults, { depth: null, colors: true });
-    const parameters = {
-      location: 'East US',
-      properties: {
-        sku: { family: 'A', name: 'standard' },
-        accessPolicies: [],
-        enabledForDeployment: false,
-        tenantId: tenantGUID
-      }
-    };
-    console.info('Creating vault ${vaultName} ...');
-    return client.vaults.createOrUpdate(resourceGroup, vaultName, parameters);
-  })
-  .then(vault => console.dir(vault, { depth: null, colors: true }))
-  .catch(err => {
-    console.log('An error occured');
-    console.dir(err, { depth: null, colors: true });
-    return err;
-  });
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-keyvault)
 
 ## Samples
 
-- [Getting started with Key Vault in Node.js](https://azure.microsoft.com/resources/samples/key-vault-node-getting-started/)
-- [Manage Azure resources and resource groups with Node.js](https://azure.microsoft.com/resources/samples/resource-manager-node-resources-and-groups/) 
+- [Getting started with Key Vault in JavaScript](https://azure.microsoft.com/resources/samples/key-vault-node-getting-started/)
+- [Manage Azure resources and resource groups with JavaScript](https://azure.microsoft.com/resources/samples/resource-manager-node-resources-and-groups/) 
 - [Integrating Azure AD into a NodeJS web application](https://azure.microsoft.com/resources/samples/active-directory-node-webapp-openidconnect/) 
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/key-vault.md
+++ b/docs-ref-services/key-vault.md
@@ -30,7 +30,7 @@ npm install @azure/arm-keyvault
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-keyvault)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-keyvault)
 
 ## Samples
 
@@ -38,4 +38,4 @@ Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-ke
 - [Manage Azure resources and resource groups with JavaScript](https://azure.microsoft.com/resources/samples/resource-manager-node-resources-and-groups/) 
 - [Integrating Azure AD into a NodeJS web application](https://azure.microsoft.com/resources/samples/active-directory-node-webapp-openidconnect/) 
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/logic-apps.md
+++ b/docs-ref-services/logic-apps.md
@@ -38,8 +38,8 @@ npm install @azure/arm-logic
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-logic)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-logic)
 
 ### Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/logic-apps.md
+++ b/docs-ref-services/logic-apps.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Logic Apps modules for Node.js
-description: Reference for Azure Logic Apps modules for Node.js
+title: Azure Logic Apps modules for JavaScript
+description: Reference for Azure Logic Apps modules for JavaScript
 author: ecfan
 ms.author: estfan
 manager: cfowler
@@ -12,7 +12,7 @@ ms.devlang: nodejs
 ms.service: Logic Apps
 ---
 
-# Azure Logic Apps modules for Node.js
+# Azure Logic Apps modules for JavaScript
 
 Logic Apps provide a way to simplify and implement scalable integrations and workflows in the cloud. It provides a visual designer to model and automate your process as a series of steps known as a workflow. There are many connectors across the cloud and on-premises to quickly integrate across services and protocols. A logic app begins with a trigger (like 'When an account is added to Dynamics CRM') and after firing can begin many combinations of actions, conversions, and condition logic.
 
@@ -30,28 +30,16 @@ Logic Apps is a fully managed iPaaS (integration Platform as a Service) allowing
 
 ### Install the npm module
 
-Install the Azure logic module for Node.js
+Install the Azure logic module for JavaScript
 
 ```bash
-npm install azure-arm-logic
+npm install @azure/arm-logic
 ```
 
 ### Example
 
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const LogicManagement = require('azure-arm-logic');
-
-msRestAzure
-  .interactiveLogin()
-  .then(credentials => {
-    const subscriptionId = 'subscription-id';
-    const client = new LogicManagement(credentials, subscriptionId);
-    return client.workflows.listBySubscription();
-  })
-  .then(workflows => console.log(workflows));
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-logic)
 
 ### Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/logic-apps.md
+++ b/docs-ref-services/logic-apps.md
@@ -36,10 +36,8 @@ Install the Azure logic module for JavaScript
 npm install @azure/arm-logic
 ```
 
-### Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-logic)
-
 ### Samples
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-logic)
+
+* For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/media-services.md
+++ b/docs-ref-services/media-services.md
@@ -33,8 +33,8 @@ npm install @azure/arm-mediaservices
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-mediaservices)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-mediaservices)
 
 ## Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/media-services.md
+++ b/docs-ref-services/media-services.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Media Services modules for Node.js
-description: Reference for Azure Media Services modules for Node.js
+title: Azure Media Services modules for JavaScript
+description: Reference for Azure Media Services modules for JavaScript
 author: Juliako
 ms.author: juliako
 manager: cfowler
@@ -12,7 +12,7 @@ ms.devlang: nodejs
 ms.service: Media Services
 ---
 
-# Azure Media Services modules for Node.js
+# Azure Media Services modules for JavaScript
 
 Azure Media Services is an extensible cloud-based platform that enables developers to build scalable media management and delivery applications. Media Services is based on REST APIs that enable you to securely upload, store, encode, and package video or audio content for both on-demand and live streaming delivery to various clients (for example, TV, PC, and mobile devices).
 
@@ -28,29 +28,13 @@ With Azure Media Services, you can:
 Install the Azure media services npm module
 
 ```bash
-npm install azure-arm-mediaservices
+npm install @azure/arm-mediaservices
 ```
 
 ### Example
 
-This example lists all media services for a resource group.
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const mediaServicesManagement = require('azure-arm-mediaservices');
-
-const subscriptionId = 'your-subscription-id';
-const resourceGroup = 'your-resource-group';
-let mediaServicesClient;
-
-msRestAzure.interactiveLogin().then(credentials => {
-  mediaServicesClient = new mediaServicesManagement(credentials, subscriptionId);
-  mediaServicesClient.mediaServiceOperations
-    .listByResourceGroup(resourceGroup)
-    .then(mediaServices => console.log('Retrieved media services: ', mediaServices));
-});
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-mediaservices)
 
 ## Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/media-services.md
+++ b/docs-ref-services/media-services.md
@@ -31,10 +31,8 @@ Install the Azure media services npm module
 npm install @azure/arm-mediaservices
 ```
 
-### Example
+### Samples
 
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-mediaservices)
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-mediaservices)
 
-## Samples
-
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+* For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/mixed-reality.md
+++ b/docs-ref-services/mixed-reality.md
@@ -31,4 +31,4 @@ npm install @azure/arm-mixedreality
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-mixedreality)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-mixedreality)

--- a/docs-ref-services/mixed-reality.md
+++ b/docs-ref-services/mixed-reality.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Mixed Reality Resource Management Modules for Node.js
-description: Reference for Azure Mixed Reality Resource Management for Node.js
+title: Azure Mixed Reality Resource Management Modules for JavaScript
+description: Reference for Azure Mixed Reality Resource Management for JavaScript
 author: Xiangyu Luo
 ms.author: xiangyul
 manager: dgriff
@@ -12,7 +12,7 @@ ms.devlang: nodejs
 ms.service: Mixed Reality
 ---
 
-# Azure Mixed Reality Resource Management Modules for Node.js
+# Azure Mixed Reality Resource Management Modules for JavaScript
 
 Microsoft provides a series of Azure services to empower Mixed Reality devices and applications. Currently, such services are provided:
 
@@ -31,4 +31,4 @@ npm install @azure/arm-mixedreality
 
 ### Example
 
-See the examples on this [page](https://www.npmjs.com/package/@azure/arm-mixedreality).
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-mixedreality)

--- a/docs-ref-services/mixed-reality.md
+++ b/docs-ref-services/mixed-reality.md
@@ -31,4 +31,6 @@ npm install @azure/arm-mixedreality
 
 ### Example
 
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-mixedreality)
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-mixedreality)
+
+* For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/monitor.md
+++ b/docs-ref-services/monitor.md
@@ -24,10 +24,8 @@ Cloud applications are complex with many moving parts. Monitoring provides data 
 pm install @azure/arm-monitor
 ```
 
-### Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-monitor)
-
 ### Samples
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-monitor)
+
+* For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/monitor.md
+++ b/docs-ref-services/monitor.md
@@ -26,8 +26,8 @@ pm install @azure/arm-monitor
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-monitor)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-monitor)
 
 ### Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/monitor.md
+++ b/docs-ref-services/monitor.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Monitor modules for Node.js
-description: Reference for Azure Monitor modules for Node.js
+title: Azure Monitor modules for JavaScript
+description: Reference for Azure Monitor modules for JavaScript
 author: rbouche
 ms.author: robb
 manager: carmonm
@@ -12,7 +12,7 @@ ms.devlang: nodejs
 ms.service: Monitor
 ---
 
-# Azure Monitor modules for Node.js
+# Azure Monitor modules for JavaScript
 
 Cloud applications are complex with many moving parts. Monitoring provides data to ensure that your application stays up and running in a healthy state. It also helps you to stave off potential problems or troubleshoot past ones. In addition, you can use monitoring data to gain deep insights about your application. That knowledge can help you to improve application performance or maintainability, or automate actions that would otherwise require manual intervention.
 
@@ -21,31 +21,13 @@ Cloud applications are complex with many moving parts. Monitoring provides data 
 ### Install npm module
 
 ```bash
-npm install azure-arm-monitor
+pm install @azure/arm-monitor
 ```
 
 ### Example
 
-This code example prints all the alerting rules associated with a resource group.
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const monitorManagementClient = require('azure-arm-monitor');
-
-const subscriptionId = 'your-subscription-id';
-const resourceGroupName = 'your-resource-group-name';
-
-msRestAzure
-  .interactiveLogin()
-  .then(credentials => {
-    const client = new monitorManagementClient(credentials, subscriptionId);
-    client.alertRules.listByResourceGroup(resourceGroupName, rules => {
-      console.log('List of rules:');
-      console.dir(rules, { depth: null, colors: true });
-    })
-  });
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-monitor)
 
 ### Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/mysql.md
+++ b/docs-ref-services/mysql.md
@@ -56,7 +56,7 @@ connection.end();
 * [Perform queries using JavaScript and MySQL](https://github.com/mysqljs/mysql/blob/master/Readme.md#performing-queries)
 * [MySQL transactions in JavaScript](https://github.com/mysqljs/mysql/blob/master/Readme.md#transactions)
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
 
 ## Management SDK
 
@@ -70,4 +70,4 @@ npm install @azure/arm-mysql
 
 ### Example code
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-mysql)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-mysql)

--- a/docs-ref-services/mysql.md
+++ b/docs-ref-services/mysql.md
@@ -1,6 +1,6 @@
 ---
-title: Azure MySQL modules for Node.js
-description: Reference for Azure MySQL modules for Node.js
+title: Azure MySQL modules for JavaScript
+description: Reference for Azure MySQL modules for JavaScript
 author: ajlam
 ms.author: andrela
 ms.date: 07/18/2017
@@ -9,9 +9,9 @@ ms.devlang: nodejs
 ms.service: mysql
 ---
 
-# Azure MySQL modules for Node.js
+# Azure MySQL modules for JavaScript
 
-The recommended client library for accessing Azure Database for MySQL is the open-source [Node.js connection library for Azure Database for MySQL](https://github.com/sidorares/node-mysql2). 
+The recommended client library for accessing Azure Database for MySQL is the open-source [JavaScript connection library for Azure Database for MySQL](https://github.com/sidorares/node-mysql2). 
 
 Learn more about [Azure Database for MySQL](https://docs.microsoft.com/azure/MySQL/)
 
@@ -29,7 +29,7 @@ npm install mysql2
 
 This example connects to a MySQL database and performs a simple query to retrieve all customers.
 
-```javascript
+```JavaScript
 const mysql = require('mysql2');
 
 const connection = mysql.createConnection({
@@ -52,8 +52,22 @@ connection.end();
 
 ## Samples
 
-* [Create a connection to MySQL using Node.js](https://github.com/mysqljs/mysql/blob/master/Readme.md#establishing-connections)
-* [Perform queries using Node.js and MySQL](https://github.com/mysqljs/mysql/blob/master/Readme.md#performing-queries)
-* [MySQL transactions in Node.js](https://github.com/mysqljs/mysql/blob/master/Readme.md#transactions)
+* [Create a connection to MySQL using JavaScript](https://github.com/mysqljs/mysql/blob/master/Readme.md#establishing-connections)
+* [Perform queries using JavaScript and MySQL](https://github.com/mysqljs/mysql/blob/master/Readme.md#performing-queries)
+* [MySQL transactions in JavaScript](https://github.com/mysqljs/mysql/blob/master/Readme.md#transactions)
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+
+## Management SDK
+
+Create, update, or delete MySQL instances using Management SDK
+
+### Installation
+
+```
+npm install @azure/arm-mysql
+```
+
+### Example code
+
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-mysql)

--- a/docs-ref-services/mysql.md
+++ b/docs-ref-services/mysql.md
@@ -56,7 +56,7 @@ connection.end();
 * [Perform queries using JavaScript and MySQL](https://github.com/mysqljs/mysql/blob/master/Readme.md#performing-queries)
 * [MySQL transactions in JavaScript](https://github.com/mysqljs/mysql/blob/master/Readme.md#transactions)
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).
 
 ## Management SDK
 

--- a/docs-ref-services/notification-hubs.md
+++ b/docs-ref-services/notification-hubs.md
@@ -36,11 +36,11 @@ npm install @azure/arm-notificationhubs
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-notificationhubs)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-notificationhubs)
 
 ## Samples
 
 * [App Service Mobile completed quickstart for JavaScript backend](https://azure.microsoft.com/resources/samples/app-service-mobile-nodejs-backend-quickstart/)
 * [Tweet vibration anomalies detected by Azure IoT services on data from an Intel Edison running JavaScript](https://azure.microsoft.com/resources/samples/iot-hub-nodejs-intel-edison-vibration-anomaly-detection/)
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/notification-hubs.md
+++ b/docs-ref-services/notification-hubs.md
@@ -34,13 +34,10 @@ Install the Azure Notification Hubs module
 npm install @azure/arm-notificationhubs
 ```
 
-### Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-notificationhubs)
-
 ## Samples
 
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-notificationhubs)
 * [App Service Mobile completed quickstart for JavaScript backend](https://azure.microsoft.com/resources/samples/app-service-mobile-nodejs-backend-quickstart/)
 * [Tweet vibration anomalies detected by Azure IoT services on data from an Intel Edison running JavaScript](https://azure.microsoft.com/resources/samples/iot-hub-nodejs-intel-edison-vibration-anomaly-detection/)
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/notification-hubs.md
+++ b/docs-ref-services/notification-hubs.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Notification Hubs modules for Node.js
-description: Reference for Azure Notification Hubs modules for Node.js
+title: Azure Notification Hubs modules for JavaScript
+description: Reference for Azure Notification Hubs modules for JavaScript
 author: rloutlaw
 ms.author: ROutlaw
 manager: angrobe
@@ -12,7 +12,7 @@ ms.devlang: nodejs
 ms.service: Notification Hubs
 ---
 
-# Azure Notification Hubs modules for Node.js
+# Azure Notification Hubs modules for JavaScript
 
 Azure Notification Hubs provide an easy-to-use, multi-platform, scaled-out push engine. With a single cross-platform API call, you can easily send targeted and personalized push notifications to any mobile platform from any cloud or on-premises backend.
 
@@ -31,33 +31,16 @@ Notification Hubs works great for both enterprise and consumer scenarios. Here a
 Install the Azure Notification Hubs module 
 
 ```bash
-npm install azure-arm-notificationhubs
+npm install @azure/arm-notificationhubs
 ```
 
 ### Example
 
-This example lists all notification hubs.
-
- ```javascript
-const msRestAzure = require('ms-rest-azure');
-const notificationHubsManagementClient = require('azure-arm-notificationhubs');
-
-const subscriptionId = 'your-subscription-id';
-const notificationHubNamespace = 'your-hub-namespace';
-const resourceGroup = 'your-resource-group';
-let notificationHubsClient;
-
-msRestAzure.interactiveLogin().then(credentials => {
-  notificationHubsClient = new notificationHubsManagementClient(credentials, subscriptionId);
-  notificationHubsClient.notificationHubs
-    .list(resourceGroup, notificationHubNamespace)
-    .then(notificationHubs => console.log('Retrieved notification hubs: ', notificationHubs));
-});
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-notificationhubs)
 
 ## Samples
 
-* [App Service Mobile completed quickstart for Node.js backend](https://azure.microsoft.com/resources/samples/app-service-mobile-nodejs-backend-quickstart/)
-* [Tweet vibration anomalies detected by Azure IoT services on data from an Intel Edison running Node.js](https://azure.microsoft.com/resources/samples/iot-hub-nodejs-intel-edison-vibration-anomaly-detection/)
+* [App Service Mobile completed quickstart for JavaScript backend](https://azure.microsoft.com/resources/samples/app-service-mobile-nodejs-backend-quickstart/)
+* [Tweet vibration anomalies detected by Azure IoT services on data from an Intel Edison running JavaScript](https://azure.microsoft.com/resources/samples/iot-hub-nodejs-intel-edison-vibration-anomaly-detection/)
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/operational-insights.md
+++ b/docs-ref-services/operational-insights.md
@@ -20,10 +20,8 @@ Use npm to install the Azure Operational Insights module for JavaScript
 npm install @azure/arm-operationalinsights
 ```
 
-### Example 
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-operationalinsights)
-
 ## Samples
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-operationalinsights)
+
+* For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/operational-insights.md
+++ b/docs-ref-services/operational-insights.md
@@ -22,8 +22,8 @@ npm install @azure/arm-operationalinsights
 
 ### Example 
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-operationalinsights)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-operationalinsights)
 
 ## Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/operational-insights.md
+++ b/docs-ref-services/operational-insights.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Operational Insights Modules for Node.js
-description: Reference for Azure Operational Insights Modules for Node.js
+title: Azure Operational Insights Modules for JavaScript
+description: Reference for Azure Operational Insights Modules for JavaScript
 author: MGoedtel
 ms.author: magoedte
 manager: carmonm
@@ -12,36 +12,18 @@ ms.devlang: nodejs
 ms.service: Operational Insights
 ---
 
-# Azure Operational Insights Modules for Node.js
+# Azure Operational Insights Modules for JavaScript
 
-Use npm to install the Azure Operational Insights module for Node.js
+Use npm to install the Azure Operational Insights module for JavaScript
 
 ```bash
-npm install azure-arm-operationalinsights
+npm install @azure/arm-operationalinsights
 ```
 
 ### Example 
 
-This example creates a client, connects to Operational Insights and retreives a list of workspaces by a specified resource group.
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const OperationalInsightsManagement = require('azure-arm-operationalinsights');
-
-const subscriptionId = 'your-subscription-id';
-
-msRestAzure.interactiveLogin().then(credentials => {
-    const client = new OperationalInsightsManagement(
-        credentials,
-        subscriptionId
-    );
-    return client.workspaces.listByResourceGroup('resource-group-name');
-})
-.then(workspaces => {
-    console.log(workspaces);
-});
-``` 
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-operationalinsights)
 
 ## Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/postgresql.md
+++ b/docs-ref-services/postgresql.md
@@ -1,6 +1,6 @@
 ---
-title: Azure PostgreSQL modules for Node.js
-description: Reference for Azure PostgreSQL modules for Node.js
+title: Azure PostgreSQL modules for JavaScript
+description: Reference for Azure PostgreSQL modules for JavaScript
 author: rachel-msft
 ms.author: raagyema
 manager: sukamat
@@ -10,10 +10,10 @@ ms.devlang: nodejs
 ms.service: postgresql
 ---
 
-# Azure PostgreSQL modules for Node.js
+# Azure PostgreSQL modules for JavaScript
 
-The recommended client library for accessing Azure Database for PostgreSQL is the open-source [Node.js connection library for Azure Database for PostgreSQL](https://www.npmjs.com/package/pg). 
-This library is a non-blocking PostgreSQL client for Node.js, supporting pure JavaScript and optional native libpq bindings.
+The recommended client library for accessing Azure Database for PostgreSQL is the open-source [JavaScript connection library for Azure Database for PostgreSQL](https://www.npmjs.com/package/pg). 
+This library is a non-blocking PostgreSQL client for JavaScript, supporting pure JavaScript and optional native libpq bindings.
 
 Learn more about [Azure Database for PostgreSQL](https://docs.microsoft.com/azure/postgresql/)
 
@@ -31,7 +31,7 @@ npm install pg
 
 This example opens a client connection and executes a simple query.
 
-```javascript
+```JavaScript
 const pg = require('pg');
 
 const connectionString =
@@ -50,6 +50,6 @@ client.query(query, (err, res) => {
 
 | | |
 |--|--|
-| [Node.js code snippets using PostgreSQL](https://www.npmjs.com/package/pg) | Learn how to create a pool, execute a query, obtain an exclusive client, and more.
+| [JavaScript code snippets using PostgreSQL](https://www.npmjs.com/package/pg) | Learn how to create a pool, execute a query, obtain an exclusive client, and more.
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/postgresql.md
+++ b/docs-ref-services/postgresql.md
@@ -52,4 +52,4 @@ client.query(query, (err, res) => {
 |--|--|
 | [JavaScript code snippets using PostgreSQL](https://www.npmjs.com/package/pg) | Learn how to create a pool, execute a query, obtain an exclusive client, and more.
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/postgresql.md
+++ b/docs-ref-services/postgresql.md
@@ -52,4 +52,4 @@ client.query(query, (err, res) => {
 |--|--|
 | [JavaScript code snippets using PostgreSQL](https://www.npmjs.com/package/pg) | Learn how to create a pool, execute a query, obtain an exclusive client, and more.
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/powerbi-embedded.md
+++ b/docs-ref-services/powerbi-embedded.md
@@ -1,6 +1,6 @@
 ---
-title: Azure PowerBI Embedded modules for Node.js
-description: Reference for Azure PowerBI Embedded modules for Node.js
+title: Azure PowerBI Embedded modules for JavaScript
+description: Reference for Azure PowerBI Embedded modules for JavaScript
 author: rkarlin
 ms.author: rkarlin
 manager: kfile
@@ -12,7 +12,7 @@ ms.devlang: nodejs
 ms.service: PowerBI Embedded
 ---
 
-# Azure PowerBI Embedded modules for Node.js
+# Azure PowerBI Embedded modules for JavaScript
 
 With the Power BI Embedded Azure service, you can integrate Power BI reports right into your node application to create or edit charts and reports.
 
@@ -25,50 +25,13 @@ Learn more about [Power BI Embedded](https://powerbi.microsoft.com/documentation
 Install the Azure Power BI npm module
 
 ```bash
-npm install azure-arm-powerbiembedded
+npm install @azure/arm-powerbiembedded
 ```
 
 ### Example
 
-This example creates a workspace collection in an existing resource group.
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const PowerBIEmbeddedManagementClient = require('azure-arm-powerbiembedded');
-
-const creationOptions = {
-  location: 'northcentralus',
-  tags: {
-    key1: 'value1',
-    key2: 'value2'
-  },
-  sku: {
-    name: 'S1',
-    teir: 'Standard'
-  }
-};
-
-const subscriptionId = 'your-subscription-id';
-const resourceGroup = 'your-resource-group-name';
-const workspace = 'workspace-collection-name';
-
-msRestAzure
-  .interactiveLogin()
-  .then(credentials => {
-    const client = new PowerBIEmbeddedManagementClient(
-      credentials,
-      subscriptionId
-    );
-    return client.workspaceCollections.create(
-      resourceGroup,
-      workspace,
-      creationOptions
-    );
-  })
-  .then(workspaces => console.dir(workspaces, { depth: null, colors: true }))
-  .catch(err => console.log(err));
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-powerbiembedded)
 
 ## Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/powerbi-embedded.md
+++ b/docs-ref-services/powerbi-embedded.md
@@ -28,10 +28,8 @@ Install the Azure Power BI npm module
 npm install @azure/arm-powerbiembedded
 ```
 
-### Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-powerbiembedded)
-
 ## Samples
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-powerbiembedded)
+
+* For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/powerbi-embedded.md
+++ b/docs-ref-services/powerbi-embedded.md
@@ -30,8 +30,8 @@ npm install @azure/arm-powerbiembedded
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-powerbiembedded)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-powerbiembedded)
 
 ## Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/redis-cache.md
+++ b/docs-ref-services/redis-cache.md
@@ -63,10 +63,10 @@ npm install @azure/arm-rediscache
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-rediscache)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-rediscache)
 
 ## Samples
 
 * [How to use Azure Redis Cache with JavaScript](https://docs.microsoft.com/azure/redis-cache/cache-nodejs-get-started)
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/redis-cache.md
+++ b/docs-ref-services/redis-cache.md
@@ -61,12 +61,10 @@ Use npm to install the Azure Redis Cache modules for JavaScript
 npm install @azure/arm-rediscache
 ```
 
-### Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-rediscache)
-
 ## Samples
+
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-rediscache)
 
 * [How to use Azure Redis Cache with JavaScript](https://docs.microsoft.com/azure/redis-cache/cache-nodejs-get-started)
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/redis-cache.md
+++ b/docs-ref-services/redis-cache.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Redis Cache modules for Node.js
-description: Reference for Azure Redis Cache modules for Node.js
+title: Azure Redis Cache modules for JavaScript
+description: Reference for Azure Redis Cache modules for JavaScript
 author: wesmc7777
 ms.author: wesmc
 manager: cfowler
@@ -12,7 +12,7 @@ ms.devlang: nodejs
 ms.service: Redis Cache
 ---
 
-# Azure Redis Cache modules for Node.js
+# Azure Redis Cache modules for JavaScript
 
 Azure Redis Cache is based on the popular open source Redis project. It gives you access to a secure, dedicated Redis instance, managed by Microsoft and accessible from your Azure apps.
 
@@ -24,7 +24,7 @@ Learn more about [Azure Redis Cache](https://docs.microsoft.com/azure/redis-cach
 
 ### Install the npm module
 
-Use npm to install the Redis module for Node.js
+Use npm to install the Redis module for JavaScript
 
 ```bash
 npm install redis
@@ -34,7 +34,7 @@ npm install redis
 
 This example connects to an Azure Redis Cache instance, stores a key/value pair and then reads the stored value by its key.
 
-```javascript
+```JavaScript
 const redis = require('redis');
 
 const client = redis.createClient(6380, '<name>.redis.cache.windows.net', {
@@ -55,31 +55,18 @@ client.get('key1', (err, reply) => {
 
 ### Install the npm module
 
-Use npm to install the Azure Redis Cache modules for Node.js
+Use npm to install the Azure Redis Cache modules for JavaScript
 
 ```bash
-npm install azure-arm-rediscache
+npm install @azure/arm-rediscache
 ```
 
 ### Example
 
-This example authenticates to Azure and lists all Redis Cache instances in a specified resource group.
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const AzureMgmtRedisCache = require('azure-arm-rediscache');
-
-msRestAzure.interactiveLogin().then(credentials => {
-  const client = new AzureMgmtRedisCache(credentials, 'my-subscription-id');
-  client.redis.listByResourceGroup('testResourceGroup').then(result => {
-    console.log(result);
-  });
-});
-```
-
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-rediscache)
 
 ## Samples
 
-* [How to use Azure Redis Cache with Node.js](https://docs.microsoft.com/azure/redis-cache/cache-nodejs-get-started)
+* [How to use Azure Redis Cache with JavaScript](https://docs.microsoft.com/azure/redis-cache/cache-nodejs-get-started)
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/relay.md
+++ b/docs-ref-services/relay.md
@@ -28,10 +28,8 @@ Install the Azure Relay npm module
 npm install @azure/arm-relay
 ```
 
-### Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-relay)
-
 ## Samples
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-relay)
+
+* For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/relay.md
+++ b/docs-ref-services/relay.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Relay modules for Node.js
-description: Reference for Azure Relay modules for Node.js
+title: Azure Relay modules for JavaScript
+description: Reference for Azure Relay modules for JavaScript
 author: sethmanheim
 ms.author: sethm
 manager: timlt
@@ -12,7 +12,7 @@ ms.devlang: nodejs
 ms.service: Relay
 ---
 
-# Azure Relay modules for Node.js
+# Azure Relay modules for JavaScript
 
 The Azure Relay service creates hybrid applications by enabling you to securely expose services that reside within a corporate enterprise network to the public cloud, without having to open a firewall connection, or require intrusive changes to a corporate network infrastructure. Relay supports a variety of different transport protocols and web services standards.
 
@@ -25,31 +25,13 @@ Learn more about [Azure Relay](https://docs.microsoft.com/azure/service-bus-rela
 Install the Azure Relay npm module
 
 ```bash
-npm install azure-arm-relay
+npm install @azure/arm-relay
 ```
 
 ### Example
 
-This example lists the namespaces for a Relay client.
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const RelayManagement = require('azure-arm-relay');
-
-const subscriptionId = 'your-subscription-id';
-
-msRestAzure
-  .interactiveLogin()
-  .then(credentials => {
-    const client = new RelayManagement(credentials, subscriptionId);
-    return client.namespaces.list();
-  })
-  .then(namespaces => {
-    console.dir(namespaces, { depth: null, colors: true });
-  })
-  .catch(err => console.log(err));
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-relay)
 
 ## Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/relay.md
+++ b/docs-ref-services/relay.md
@@ -30,8 +30,8 @@ npm install @azure/arm-relay
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-relay)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-relay)
 
 ## Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/resources.md
+++ b/docs-ref-services/resources.md
@@ -30,8 +30,8 @@ npm install @azure/arm-resources
 
 ## Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-resources)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-resources)
 
 ## Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/resources.md
+++ b/docs-ref-services/resources.md
@@ -28,10 +28,8 @@ Use npm to install the Azure Resource Manager module for JavaScript
 npm install @azure/arm-resources
 ```
 
-## Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-resources)
-
 ## Samples
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-resources)
+
+* For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/resources.md
+++ b/docs-ref-services/resources.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Resource Manager modules for Node.js
-description: Reference for Azure Resource Manager modules for Node.js
+title: Azure Resource Manager modules for JavaScript
+description: Reference for Azure Resource Manager modules for JavaScript
 author: tfitzmac
 ms.author: tomfitz
 manager: timlt
@@ -12,7 +12,7 @@ ms.devlang: nodejs
 ms.service: Resources
 ---
 
-# Azure Resource modules for Node.js
+# Azure Resource modules for JavaScript
 
 Azure Resource Manager enables you to deploy and manage the infrastructure for your Azure solutions. Organize related resources in resource groups and deploy your resources via JSON templates.
 
@@ -20,16 +20,18 @@ Learn more about [Azure Resources](https://docs.microsoft.com/azure/azure-resour
 
 ## Install the modules with npm
 
-Use npm to install the Azure Resource Manager module for Node.js
+Use npm to install the Azure Resource Manager module for JavaScript
 
 ### Management
 
 ```bash
-npm install azure-arm-resource
+npm install @azure/arm-resources
 ```
 
 ## Example
 
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-resources)
+
 ## Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/scheduler.md
+++ b/docs-ref-services/scheduler.md
@@ -32,8 +32,8 @@ npm install azure-arm-scheduler
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/azure-arm-scheduler)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/azure-arm-scheduler)
 
 ## Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/scheduler.md
+++ b/docs-ref-services/scheduler.md
@@ -30,10 +30,8 @@ Install the Azure Scheduler npm module
 npm install azure-arm-scheduler
 ```
 
-### Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/azure-arm-scheduler)
-
 ## Samples
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/azure-arm-scheduler)
+
+* For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/scheduler.md
+++ b/docs-ref-services/scheduler.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Scheduler modules for Node.js
-description: Reference for Azure Scheduler modules for Node.js
+title: Azure Scheduler modules for JavaScript
+description: Reference for Azure Scheduler modules for JavaScript
 author: rloutlaw
 ms.author: ROutlaw
 manager: angrobe
@@ -12,7 +12,7 @@ ms.devlang: nodejs
 ms.service: Scheduler
 ---
 
-# Azure Scheduler modules for Node.js
+# Azure Scheduler modules for JavaScript
 
 Azure Scheduler creates, maintains, and invokes scheduled work via HTTP, HTTPS, a storage queue, or the [Azure Service Bus](/azure/service-bus-messaging/service-bus-messaging-overview).
 
@@ -32,26 +32,8 @@ npm install azure-arm-scheduler
 
 ### Example
 
-This examples lists the current schedulers.
-
-```javascript
-const msRestAzure = require('ms-rest-azure')
-const SchedulerManagement = require('azure-arm-scheduler')
-
-msRestAzure.interactiveLogin().then(credentials => {
-    // Create a scheduler from the login credentials
-    let client = new SchedulerManagement(credentials, 'your-subscription-id')
-    // Get the full list of current jobs for the subscription
-    return client.jobCollections.listBySubscription()
-}).then(currentJobs => {
-    console.log("Current jobs:")
-    console.dir(currentJobs, {depth:null, colors:true})
-}).catch(error => {
-    console.log("An error occurred:")
-    console.dir(error, {depth:null, colors:true})
-})
-```
+Example can be found here: [Example](https://www.npmjs.com/package/azure-arm-scheduler)
 
 ## Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/search.md
+++ b/docs-ref-services/search.md
@@ -31,8 +31,8 @@ npm install @azure/arm-search
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-search)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-search)
 
 ## Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/search.md
+++ b/docs-ref-services/search.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Search resource management modules for Node.js
-description: Introduction to the Node.js resource management modules for Azure Search.
+title: Azure Search resource management modules for JavaScript
+description: Introduction to the JavaScript resource management modules for Azure Search.
 author: HeidiSteen
 manager: nitinme
 ms.author: heidist
@@ -13,11 +13,11 @@ ms.service: search
 
 ---
 
-# Node.js resource management modules for Azure Search
+# JavaScript resource management modules for Azure Search
 
-Azure Search is a search-as-a-service cloud solution that gives developers APIs and tools for adding a rich search experience over private, heterogeneous content in web, mobile, and enterprise applications. This Node.js module provides resource management APIs for creating and updating a search service, managing access keys, and allocating replicas and partitionss. You cannot change tiers (SKU) or location with these APIs.
+Azure Search is a search-as-a-service cloud solution that gives developers APIs and tools for adding a rich search experience over private, heterogeneous content in web, mobile, and enterprise applications. This JavaScript module provides resource management APIs for creating and updating a search service, managing access keys, and allocating replicas and partitionss. You cannot change tiers (SKU) or location with these APIs.
 
-For more information about the service and related features, see [Introduction to Azure Search](https://docs.microsoft.com/azure/search/search-what-is-azure-search), [Service administration for Azure Search](https://docs.microsoft.com/azure/search/search-manage), and [Quickstart: Create an Azure Search index in Node.js](https://docs.microsoft.com/azure/search/search-get-started-nodejs).
+For more information about the service and related features, see [Introduction to Azure Search](https://docs.microsoft.com/azure/search/search-what-is-azure-search), [Service administration for Azure Search](https://docs.microsoft.com/azure/search/search-manage), and [Quickstart: Create an Azure Search index in JavaScript](https://docs.microsoft.com/azure/search/search-get-started-nodejs).
 
 ## Management package
 
@@ -26,33 +26,13 @@ For more information about the service and related features, see [Introduction t
 Install the Azure Search npm module
 
 ```bash
-npm install azure-arm-search
+npm install @azure/arm-search
 ```
 
 ### Example
 
-This example creates a new Search service in Azure, and lists the resources in its resource group.
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const SearchManagement = require('azure-arm-search');
-
-const subscriptionId = 'your-subscription-id';
-const resourceGroup = 'yourResourceGroup';
-
-msRestAzure
-  .interactiveLogin()
-  .then(credentials => {
-    const client = new SearchManagement(credentials, subscriptionId);
-    return client.services.listByResourceGroup(resourceGroup);
-  })
-  .then(services => console.dir(services, { depth: null, colors: true }))
-  .catch(err => {
-    console.log('An error ocurred');
-    console.dir(err, { depth: null, colors: true });
-  });
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-search)
 
 ## Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/search.md
+++ b/docs-ref-services/search.md
@@ -29,10 +29,8 @@ Install the Azure Search npm module
 npm install @azure/arm-search
 ```
 
-### Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-search)
-
 ## Samples
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-search)
+
+* For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/server-management.md
+++ b/docs-ref-services/server-management.md
@@ -31,8 +31,8 @@ npm install azure-arm-servermanagement
 
 ## Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/azure-arm-servermanagement)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/azure-arm-servermanagement)
 
 ## Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/server-management.md
+++ b/docs-ref-services/server-management.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Server Management modules for Node.js
-description: Reference for Azure Server Management modules for Node.js
+title: Azure Server Management modules for JavaScript
+description: Reference for Azure Server Management modules for JavaScript
 author: rloutlaw
 ms.author: ROutlaw
 manager: angrobe
@@ -12,16 +12,16 @@ ms.devlang: nodejs
 ms.service: Server Management
 ---
 
-# Azure Server Management modules for Node.js
+# Azure Server Management modules for JavaScript
 
 The Azure Server Manager allows you to manage nodes, gateways, sessions, and PowerShell commands and sessions.
 
 > [!WARNING]
-> This API is deprecated in favor of using the [Azure Resource Manager](/javascript/api/overview/azure/resources), and it may not work with all services.
+> This API is deprecated in favor of using the [Azure Resource Manager](/JavaScript/api/overview/azure/resources), and it may not work with all services.
 
 ## Install the module with npm
 
-Use npm to install the Azure Server Management module for Node.js
+Use npm to install the Azure Server Management module for JavaScript
 
 ### Management
 
@@ -31,6 +31,8 @@ npm install azure-arm-servermanagement
 
 ## Example
 
+Example can be found here: [Example](https://www.npmjs.com/package/azure-arm-servermanagement)
+
 ## Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/server-management.md
+++ b/docs-ref-services/server-management.md
@@ -29,10 +29,8 @@ Use npm to install the Azure Server Management module for JavaScript
 npm install azure-arm-servermanagement
 ```
 
-## Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/azure-arm-servermanagement)
-
 ## Samples
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/azure-arm-servermanagement)
+
+* For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/service-bus.md
+++ b/docs-ref-services/service-bus.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Service Bus Modules for Node.js
-description: Reference for Azure Service Bus Modules for Node.js
+title: Azure Service Bus Modules for JavaScript
+description: Reference for Azure Service Bus Modules for JavaScript
 author: sethmanheim
 ms.author: sethm
 manager: timlt
@@ -12,7 +12,7 @@ ms.devlang: nodejs
 ms.service: Service Bus
 ---
 
-# Azure Service Bus Modules for Node.js
+# Azure Service Bus Modules for JavaScript
 
 Azure Service Bus is an asynchronous messaging cloud platform that enables you to send data between decoupled systems.
 
@@ -22,32 +22,16 @@ Learn more about [Azure Service Bus](https://docs.microsoft.com/azure/service-bu
 
 ### Install the npm module
 
-Use npm to install the Azure Service Bus module for Node.js
+Use npm to install the Azure Service Bus module for JavaScript
 
 ```bash
-npm install azure-arm-sb
+npm install @azure/arm-servicebus
 ```
 
 ### Example
 
-This example creates a client and then lists all Service Bus namespaces associated with a given subscription.
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const ServicebusManagement = require('azure-arm-sb');
-
-const subscriptionId = 'your-subscription-id';
-
-msRestAzure.interactiveLogin().then(credentials => {
-    const client = new ServicebusManagement(credentials, subscriptionId);
-    client.namespaces.listBySubscription().then(namespaces => {
-        namespaces.map(ns => {
-            console.log(`found ns : ${ns.name}`);
-        });
-    });
-});
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-servicebus)
 
 ## Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/service-bus.md
+++ b/docs-ref-services/service-bus.md
@@ -30,8 +30,8 @@ npm install @azure/arm-servicebus
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-servicebus)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-servicebus)
 
 ## Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/service-bus.md
+++ b/docs-ref-services/service-bus.md
@@ -28,10 +28,8 @@ Use npm to install the Azure Service Bus module for JavaScript
 npm install @azure/arm-servicebus
 ```
 
-### Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-servicebus)
-
 ## Samples
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-servicebus)
+
+* For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/service-fabric.md
+++ b/docs-ref-services/service-fabric.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Service Fabric modules for Node.js
-description: Azure Service Fabric modules for Node.js reference
+title: Azure Service Fabric modules for JavaScript
+description: Azure Service Fabric modules for JavaScript reference
 author: rwike77
 ms.author: ryanwi
 manager: timlt
@@ -12,7 +12,7 @@ ms.devlang: nodejs
 ms.service: Service Fabric
 ---
 
-# Azure Service Fabric modules for Node.js
+# Azure Service Fabric modules for JavaScript
 
 ## Overview
 
@@ -27,34 +27,13 @@ Learn more about [Azure Service Fabric](https://docs.microsoft.com/azure/service
 Install the Azure Service Fabric npm module
 
 ```bash
-npm install azure-arm-servicefabric
+npm install @azure/servicefabric
 ```
 
 ### Example
 
-This example shows how you can list the clusters for an Azure subscription.
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const ServiceFabricManagement = require('azure-arm-servicefabric');
-
-const subscriptionId = 'your-subscription-id';
-
-msRestAzure
-  .interactiveLogin()
-  .then(credentials => {
-    const client = new ServiceFabricManagement(
-      credentials,
-      subscriptionId
-    );
-    return client.clusters.list();
-  })
-  .then(clusters => {
-    console.log('List of clusters:');
-    console.dir(clusters, { depth: null, colors: true });
-  });
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/servicefabric)
 
 ## Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/service-fabric.md
+++ b/docs-ref-services/service-fabric.md
@@ -30,10 +30,8 @@ Install the Azure Service Fabric npm module
 npm install @azure/servicefabric
 ```
 
-### Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/servicefabric)
-
 ## Samples
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/servicefabric)
+
+* For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/service-fabric.md
+++ b/docs-ref-services/service-fabric.md
@@ -32,8 +32,8 @@ npm install @azure/servicefabric
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/servicefabric)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/servicefabric)
 
 ## Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/service-map.md
+++ b/docs-ref-services/service-map.md
@@ -30,8 +30,8 @@ npm install @azure/arm-servicemap
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-servicemap)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-servicemap)
 
 ## Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/service-map.md
+++ b/docs-ref-services/service-map.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Service Map modules for Node.js
-description: Reference for Azure Service Map modules for Node.js
+title: Azure Service Map modules for JavaScript
+description: Reference for Azure Service Map modules for JavaScript
 author: bwren
 ms.author: bwren
 manager: carmonm
@@ -12,7 +12,7 @@ ms.devlang: nodejs
 ms.service: Service Map
 ---
 
-# Azure Service Map modules for Node.js
+# Azure Service Map modules for JavaScript
 
 Service Map automatically discovers application components on Windows and Linux systems and maps the communication between services. Service Map shows connections between servers, processes, and ports across any TCP-connected architecture, with no configuration required other than the installation of an agent.
 
@@ -25,30 +25,13 @@ Learn more about [Azure Service Map](https://docs.microsoft.com/azure/operations
 Install the Azure Service Map npm module
 
 ```bash
-npm install azure-arm-servicemap
+npm install @azure/arm-servicemap
 ```
 
 ### Example
 
-This example lists all service maps for the specified resource group and workspace.
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const serviceMapManagement = require('azure-arm-servicemap');
-
-const subscriptionId = 'your-subscription-id';
-const resourceGroup = 'your-resource-group';
-const workspace = 'your-workspace';
-let serviceMapClient;
-
-msRestAzure.interactiveLogin().then(credentials => {
-  serviceMapClient = new serviceMapManagement(credentials, subscriptionId);
-  serviceMapClient.machineGroups
-    .listByWorkspace(resourceGroup, workspace)
-    .then(machineGroups => console.log('Retrieved machine groups: ', machineGroups));
-});
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-servicemap)
 
 ## Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/service-map.md
+++ b/docs-ref-services/service-map.md
@@ -28,10 +28,8 @@ Install the Azure Service Map npm module
 npm install @azure/arm-servicemap
 ```
 
-### Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-servicemap)
-
 ## Samples
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-servicemap)
+
+* For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/site-recovery.md
+++ b/docs-ref-services/site-recovery.md
@@ -28,10 +28,8 @@ Install the Azure Site Recovery service npm module
 npm install @azure/arm-recoveryservices
 ```
 
-### Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-recoveryservices)
-
 ## Samples
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-recoveryservices)
+
+* For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/site-recovery.md
+++ b/docs-ref-services/site-recovery.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Site Recovery modules for Node.js
-description: Reference for Azure Site Recovery modules for Node.js
+title: Azure Site Recovery modules for JavaScript
+description: Reference for Azure Site Recovery modules for JavaScript
 author: rayne-wiselman
 ms.author: raynew
 manager: carmonm
@@ -12,7 +12,7 @@ ms.devlang: nodejs
 ms.service: Site Recovery
 ---
 
-# Azure Site Recovery modules for Node.js
+# Azure Site Recovery modules for JavaScript
 
 Site Recovery allows you to automate replication of Azure VMs between regions, on-premises virtual machines and physical servers to Azure, and on-premises machines to a secondary datacenter.
 
@@ -25,32 +25,13 @@ Learn more about [Azure Site Recovery](https://docs.microsoft.com/azure/site-rec
 Install the Azure Site Recovery service npm module
 
 ```bash
-npm install azure-arm-recoveryservices
+npm install @azure/arm-recoveryservices
 ```
 
 ### Example
 
-This example lists the Site Recovery service for a resource group.
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const RecoveryServicesManagement = require('azure-arm-recoveryservices');
-
-const subscriptionId = 'your-subscription-id';
-const resourceGroupName = 'your-resource-group-name';
-
-msRestAzure
-  .interactiveLogin()
-  .then(credentials => {
-    const client = new RecoveryServicesManagement(credentials, subscriptionId);
-    return client.vaults.listByResourceGroup(resourceGroupName);
-  })
-  .then(vaults => {
-    console.log('List of vaults:');
-    console.dir(vaults, { depth: null, colors: true });
-  });
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-recoveryservices)
 
 ## Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/site-recovery.md
+++ b/docs-ref-services/site-recovery.md
@@ -30,8 +30,8 @@ npm install @azure/arm-recoveryservices
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-recoveryservices)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-recoveryservices)
 
 ## Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/speech-service.md
+++ b/docs-ref-services/speech-service.md
@@ -30,7 +30,7 @@ npm install microsoft-cognitiveservices-speech-sdk
 
 The following code snippets illustrates how to do simple speech recognition from a file:
 
-```javascript 
+```JavaScript 
 // Pull in the required packages.
 var sdk = require("microsoft-cognitiveservices-speech-sdk");
 var fs = require("fs");
@@ -85,6 +85,6 @@ Check out our [step-by-step quickstart](/azure/cognitive-services/speech-service
 
 ## Samples
 
-* [Step-by-step quickstart for Node.js](/azure/cognitive-services/speech-service/quickstart-js-node).
+* [Step-by-step quickstart for JavaScript](/azure/cognitive-services/speech-service/quickstart-js-node).
 * [Step-by-step quickstart for the browser](/azure/cognitive-services/speech-service/quickstart-js-browser).
 * More samples can be found in our [Speech SDK sample repository](https://aka.ms/csspeech/samples).

--- a/docs-ref-services/sql.md
+++ b/docs-ref-services/sql.md
@@ -73,12 +73,10 @@ Install the Azure SQL Server management npm module
 npm install @azure/arm-sql
 ```   
 
-### Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-sql)
-
 ## Samples
+
+- Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-sql)
 
 - [Azure SQL Database: Use JavaScript to connect and query data](https://docs.microsoft.com/azure/sql-database/sql-database-connect-query-nodejs)
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/sql.md
+++ b/docs-ref-services/sql.md
@@ -75,10 +75,10 @@ npm install @azure/arm-sql
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-sql)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-sql)
 
 ## Samples
 
 - [Azure SQL Database: Use JavaScript to connect and query data](https://docs.microsoft.com/azure/sql-database/sql-database-connect-query-nodejs)
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/sql.md
+++ b/docs-ref-services/sql.md
@@ -1,6 +1,6 @@
 ---
-title: Azure SQL modules for Node.js
-description: Reference for Azure SQL modules for Node.js
+title: Azure SQL modules for JavaScript
+description: Reference for Azure SQL modules for JavaScript
 author: CarlRabeler
 ms.author: carlrab
 manager: craigg
@@ -11,9 +11,9 @@ ms.service: sql-database
 ms.subservice: development
 ---
 
-# Azure SQL modules for Node.js
+# Azure SQL modules for JavaScript
 
-Work with data stored in [Azure SQL Database](https://docs.microsoft.com/azure/sql-database/sql-database-technical-overview) from Node.js.
+Work with data stored in [Azure SQL Database](https://docs.microsoft.com/azure/sql-database/sql-database-technical-overview) from JavaScript.
 The management library provides an interface to make it easy to manage Microsoft Azure SQL databases.
 
 ## Client package
@@ -30,7 +30,7 @@ npm install tedious
 
 This example connects to a SQL Server database and perform a simple query.
 
-```javascript
+```JavaScript
 const Connection = require('tedious').Connection;
 const Request = require('tedious').Request;
 
@@ -70,29 +70,15 @@ const executeStatement = () => {
 Install the Azure SQL Server management npm module
 
 ```
-npm install azure-arm-sql
+npm install @azure/arm-sql
 ```   
 
 ### Example
 
-Authenticate, create a client, and list all servers.
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const SQLManagement = require('azure-arm-sql');
-
-msRestAzure
-  .interactiveLogin()
-  .then(credentials => {
-    const client = new SQLManagement(credentials, 'your-subscription-id');
-    return client.servers.list();
-  })
-  .then(servers => console.dir(servers, { depth: null, colors: true }))
-  .catch(err => console.log(err));
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-sql)
 
 ## Samples
 
-- [Azure SQL Database: Use Node.js to connect and query data](https://docs.microsoft.com/azure/sql-database/sql-database-connect-query-nodejs)
+- [Azure SQL Database: Use JavaScript to connect and query data](https://docs.microsoft.com/azure/sql-database/sql-database-connect-query-nodejs)
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/storage.md
+++ b/docs-ref-services/storage.md
@@ -8,7 +8,7 @@ ms.date: 01/16/2019
 ms.topic: article
 ms.prod: azure
 ms.technology: azure
-ms.devlang: javascript
+ms.devlang: JavaScript
 ms.service: storage
 ---
 
@@ -20,10 +20,10 @@ ms.service: storage
 
 |Service| NPM package| Examples|Getting Started Guide|
 |---|---|---|--|
-|**Storage Blob**|[@azure/storage-blob](https://www.npmjs.com/package/@azure/storage-blob)|[storage-blob-typescript-examples](https://docs.microsoft.com/samples/azure/azure-sdk-for-js/storage-blob-typescript/)<br> [storage-blob-javascript-examples](https://docs.microsoft.com/samples/azure/azure-sdk-for-js/storage-blob-javascript/)|Read and write objects and files from [Azure Storage Blob](https://docs.microsoft.com/azure/storage/storage-nodejs-how-to-use-blob-storage)|
-|**Storage File Share**|[@azure/storage-file-share](https://www.npmjs.com/package/@azure/storage-file-share)|[storage-file-share-typescript-examples](https://docs.microsoft.com/samples/azure/azure-sdk-for-js/storage-file-share-typescript/)<br> [storage-file-share-javascript-examples](https://docs.microsoft.com/samples/azure/azure-sdk-for-js/storage-file-share-javascript/)|[Readme - Azure Storage File Share](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/storage/storage-file-share/README.md)|
-|**Storage File Datalake**|[@azure/storage-file-datalake](https://www.npmjs.com/package/@azure/storage-file-datalake)|[storage-file-datalake-typescript-examples](https://docs.microsoft.com/samples/azure/azure-sdk-for-js/storage-file-datalake-typescript/)<br> [storage-file-datalake-javascript-examples](https://docs.microsoft.com/samples/azure/azure-sdk-for-js/storage-file-datalake-javascript/)|[Readme - Azure Storage File Datalake](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/storage/storage-file-datalake/README.md)|
-|**Storage Queue**|[@azure/storage-queue](https://www.npmjs.com/package/@azure/storage-queue)|[storage-queue-typescript-examples](https://docs.microsoft.com/samples/azure/azure-sdk-for-js/storage-queue-typescript/)<br> [storage-queue-javascript-examples](https://docs.microsoft.com/samples/azure/azure-sdk-for-js/storage-queue-javascript/)|Send and receive messages between cloud-connected applications with <br>[Azure Storage Queue](https://docs.microsoft.com/azure/storage/queues/storage-quickstart-queues-nodejs)|
+|**Storage Blob**|[@azure/storage-blob](https://www.npmjs.com/package/@azure/storage-blob)|[storage-blob-typescript-examples](https://docs.microsoft.com/samples/azure/azure-sdk-for-js/storage-blob-typescript/)<br> [storage-blob-JavaScript-examples](https://docs.microsoft.com/samples/azure/azure-sdk-for-js/storage-blob-JavaScript/)|Read and write objects and files from [Azure Storage Blob](https://docs.microsoft.com/azure/storage/storage-nodejs-how-to-use-blob-storage)|
+|**Storage File Share**|[@azure/storage-file-share](https://www.npmjs.com/package/@azure/storage-file-share)|[storage-file-share-typescript-examples](https://docs.microsoft.com/samples/azure/azure-sdk-for-js/storage-file-share-typescript/)<br> [storage-file-share-JavaScript-examples](https://docs.microsoft.com/samples/azure/azure-sdk-for-js/storage-file-share-JavaScript/)|[Readme - Azure Storage File Share](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/storage/storage-file-share/README.md)|
+|**Storage File Datalake**|[@azure/storage-file-datalake](https://www.npmjs.com/package/@azure/storage-file-datalake)|[storage-file-datalake-typescript-examples](https://docs.microsoft.com/samples/azure/azure-sdk-for-js/storage-file-datalake-typescript/)<br> [storage-file-datalake-JavaScript-examples](https://docs.microsoft.com/samples/azure/azure-sdk-for-js/storage-file-datalake-JavaScript/)|[Readme - Azure Storage File Datalake](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/storage/storage-file-datalake/README.md)|
+|**Storage Queue**|[@azure/storage-queue](https://www.npmjs.com/package/@azure/storage-queue)|[storage-queue-typescript-examples](https://docs.microsoft.com/samples/azure/azure-sdk-for-js/storage-queue-typescript/)<br> [storage-queue-JavaScript-examples](https://docs.microsoft.com/samples/azure/azure-sdk-for-js/storage-queue-JavaScript/)|Send and receive messages between cloud-connected applications with <br>[Azure Storage Queue](https://docs.microsoft.com/azure/storage/queues/storage-quickstart-queues-nodejs)|
 |**Storage Table**|[azure-storage](https://www.npmjs.com/package/azure-storage)<br>(Legacy)| - |Read and write large structured data with [Azure Storage Table](https://docs.microsoft.com/azure/storage/storage-nodejs-how-to-use-table-storage)|
 |||||
 
@@ -44,28 +44,9 @@ Find more getting started guides at [Browse code samples](https://azure.microsof
 Install the Azure storage management npm module
 
 ```bash
-npm install azure-arm-storage
+npm install @azure/arm-storage
 ```
 
 ### Example
 
-This example list the storage accounts.
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const storageManagementClient = require('azure-arm-storage');
-
-const subscriptionId = 'your-subscription-id';
-
-msRestAzure
-  .interactiveLogin()
-  .then(credentials => {
-    const client = new storageManagementClient(
-      credentials,
-      subscriptionId
-    );
-    return client.storageAccounts.list();
-  })
-  .then(accounts => console.dir(accounts, { depth: null, colors: true }))
-  .catch(err => console.log(err));
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-storage)

--- a/docs-ref-services/storage.md
+++ b/docs-ref-services/storage.md
@@ -49,4 +49,4 @@ npm install @azure/arm-storage
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-storage)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-storage)

--- a/docs-ref-services/traffic-manager.md
+++ b/docs-ref-services/traffic-manager.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Traffic Manager modules for Node.js
-description: Azure Traffic Manager modules for Node.js reference
+title: Azure Traffic Manager modules for JavaScript
+description: Azure Traffic Manager modules for JavaScript reference
 author: KumudD
 ms.author: kumud
 manager: jeconnoc
@@ -12,7 +12,7 @@ ms.devlang: nodejs
 ms.service: Traffic Manager
 ---
 
-# Azure Traffic Manager modules for Node.js
+# Azure Traffic Manager modules for JavaScript
 
 ## Overview
 
@@ -27,30 +27,13 @@ Learn more about [Azure Traffic Manager](https://docs.microsoft.com/azure/traffi
 Install the Azure traffic manager npm module
 
 ```bash
-npm install azure-arm-trafficmanager
+npm install @azure/arm-trafficmanager
 ```
 
 ### Example
 
-This example lists all Traffic Managers for a given resource group.
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const trafficManager = require('azure-arm-trafficmanager');
-
-const subscriptionId = 'your-subscription-id';
-
-msRestAzure.interactiveLogin().then(credentials => {
-  const client = new trafficManager(credentials, subscriptionId);
-  const resourceGroupName = 'resource-group-name';
-  client.profiles.listAllInResourceGroup(resourceGroupName).then(profiles => {
-    profiles.map(profile => {
-      console.log(`found profile : ${profile.name}`);
-    });
-  });
-});
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-trafficmanager)
 
 ## Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/traffic-manager.md
+++ b/docs-ref-services/traffic-manager.md
@@ -30,10 +30,8 @@ Install the Azure traffic manager npm module
 npm install @azure/arm-trafficmanager
 ```
 
-### Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-trafficmanager)
-
 ## Samples
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-trafficmanager)
+
+* For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/traffic-manager.md
+++ b/docs-ref-services/traffic-manager.md
@@ -32,8 +32,8 @@ npm install @azure/arm-trafficmanager
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-trafficmanager)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-trafficmanager)
 
 ## Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/virtual-network.md
+++ b/docs-ref-services/virtual-network.md
@@ -1,6 +1,6 @@
 ---
-title: Azure Virtual Network modules for Node.js
-description: Reference for Azure Virtual Network modules for Node.js
+title: Azure Virtual Network modules for JavaScript
+description: Reference for Azure Virtual Network modules for JavaScript
 author: jimdial
 ms.author: jdial
 manager: jeconnoc
@@ -12,7 +12,7 @@ ms.devlang: nodejs
 ms.service: Virtual Network
 ---
 
-# Azure Virtual Network modules for Node.js
+# Azure Virtual Network modules for JavaScript
 
 ## Overview
 
@@ -27,32 +27,13 @@ Learn more about [Azure Virtual Network](https://docs.microsoft.com/azure/virtua
 Install the Azure Virtual Network npm module
 
 ```bash
-npm install azure-arm-network
+npm install @azure/arm-network
 ```
 
 ### Example
 
-This example gets and prints the list of virtual networks
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const NetworkManagementClient = require('azure-arm-network');
-
-const subscriptionId = 'your-subscription-id';
-const resourceGroup = 'your-resource-group-name';
-
-msRestAzure
-  .interactiveLogin()
-  .then(credentials => {
-    const client = new NetworkManagementClient(credentials, subscriptionId);
-    return client.virtualNetworks.list(resourceGroup);
-  })
-  .then(networkList => {
-    console.log('List of virtual networks:');
-    console.dir(networkList, { depth: null, colors: true });
-  });
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-network)
 
 ## Samples
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/virtual-network.md
+++ b/docs-ref-services/virtual-network.md
@@ -32,8 +32,8 @@ npm install @azure/arm-network
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-network)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-network)
 
 ## Samples
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/virtual-network.md
+++ b/docs-ref-services/virtual-network.md
@@ -30,10 +30,8 @@ Install the Azure Virtual Network npm module
 npm install @azure/arm-network
 ```
 
-### Example
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-network)
-
 ## Samples
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+* Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-network)
+
+* For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).

--- a/docs-ref-services/virtualmachines.md
+++ b/docs-ref-services/virtualmachines.md
@@ -1,6 +1,6 @@
 ---
-title: Virtual Machine Modules for Node.js - Azure
-description: Azure Virtual Machine Modules for Node.js reference guide
+title: Virtual Machine Modules for JavaScript - Azure
+description: Azure Virtual Machine Modules for JavaScript reference guide
 author: iainfoulds
 ms.author: iainfou
 manager: jeconnoc
@@ -12,11 +12,11 @@ ms.devlang: nodejs
 ms.service: compute
 ---
 
-# Azure Virtual Machine Modules for Node.js
+# Azure Virtual Machine Modules for JavaScript
 
 ## Overview
 
-Define, configure, and deploy new Windows and Linux virtual machines and virtual machine scale sets from your code with the Azure management modules for Node.js. The modules let you start and stop existing virtual machines and attach or detach disks to stopped VMs in your Azure subscription.
+Define, configure, and deploy new Windows and Linux virtual machines and virtual machine scale sets from your code with the Azure management modules for JavaScript. The modules let you start and stop existing virtual machines and attach or detach disks to stopped VMs in your Azure subscription.
 
 ## Management package
 
@@ -25,38 +25,18 @@ Define, configure, and deploy new Windows and Linux virtual machines and virtual
 Install the Azure Compute npm module
 
 ```bash
-npm install azure-arm-compute
+npm install @azure/arm-compute
 ```   
 
 ### Example
 
-The following example illustrates how to log in to Azure, create a management client, and list all VM images for the specified location, publisher, offer, and SKU.
-
-```javascript
-const msRestAzure = require('ms-rest-azure');
-const computeManagementClient = require('azure-arm-compute');
-
-const subscriptionId = 'my-subscription-id';
-
-msRestAzure.interactiveLogin().then(credentials => {
-  const client = new computeManagementClient(credentials, subscriptionId);
-
-  client.virtualMachineImages
-    .list(
-        'westus',                   // location
-        'Canonical',   // publisher name
-        'UbuntuServer',            // offer
-        '16.04-LTS'        // sku
-    )
-    .then(result => console.log(result));
-});
-```
+Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-compute)
 
 ## Samples
 
 | | |
 |---|---|
 | **Virtual machine management** ||
-| [Azure virtual machines management sample with Node.js](https://github.com/Azure-Samples/compute-node-manage-vm) | Demonstrates how to create, list, restart, and delete virtual machines. |
+| [Azure virtual machines management sample with JavaScript](https://github.com/Azure-Samples/compute-node-manage-vm) | Demonstrates how to create, list, restart, and delete virtual machines. |
 
-Explore more [sample Node.js code](https://azure.microsoft.com/resources/samples/?platform=nodejs) you can use in your apps.
+Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.

--- a/docs-ref-services/virtualmachines.md
+++ b/docs-ref-services/virtualmachines.md
@@ -30,7 +30,7 @@ npm install @azure/arm-compute
 
 ### Example
 
-Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-compute)
+Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-compute)
 
 ## Samples
 
@@ -39,4 +39,4 @@ Example can be found here: [Example](https://www.npmjs.com/package/@azure/arm-co
 | **Virtual machine management** ||
 | [Azure virtual machines management sample with JavaScript](https://github.com/Azure-Samples/compute-node-manage-vm) | Demonstrates how to create, list, restart, and delete virtual machines. |
 
-Explore more [sample JavaScript code](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript) you can use in your apps.
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).

--- a/docs-ref-services/virtualmachines.md
+++ b/docs-ref-services/virtualmachines.md
@@ -28,15 +28,13 @@ Install the Azure Compute npm module
 npm install @azure/arm-compute
 ```   
 
-### Example
+## Samples
 
 Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-compute)
-
-## Samples
 
 | | |
 |---|---|
 | **Virtual machine management** ||
 | [Azure virtual machines management sample with JavaScript](https://github.com/Azure-Samples/compute-node-manage-vm) | Demonstrates how to create, list, restart, and delete virtual machines. |
 
-For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/en-us/samples/browse/?languages=javascript).
+For more code samples that use various Azure packages, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript).


### PR DESCRIPTION
As Node.JS SDK is deprecated, some references to the old Node.JS SDK documentation must be cleaned up to avoid confusion for the users
This mostly includes
1. Change Node JS text to JavaScript 
2. Update the NPM package path to the correct JS version NPM package
3. Remove outdated code sample and put a pointer to the NPM package page, where the code example is