### PR TITLE
[Key Vault Keys] Using signData in the Sign Data section

### DIFF
--- a/docs-ref-services/keyvault-keys-readme.md
+++ b/docs-ref-services/keyvault-keys-readme.md
@@ -680,7 +680,7 @@ async function main() {
   let myKey = await keysClient.createKey("MyKey", "RSA");
   const cryptographyClient = new CryptographyClient(myKey.id, credential);
 
-  const signResult = await cryptographyClient.sign("RS256", Buffer.from("My 32 bytes, to sign with RS256."));
+  const signResult = await cryptographyClient.signData("RS256", Buffer.from("My Message"));
   console.log("sign result: ", signResult.result);
 }
 

--- a/docs-ref-services/keyvault-keys-readme.md
+++ b/docs-ref-services/keyvault-keys-readme.md
@@ -680,7 +680,7 @@ async function main() {
   let myKey = await keysClient.createKey("MyKey", "RSA");
   const cryptographyClient = new CryptographyClient(myKey.id, credential);
 
-  const signResult = await cryptographyClient.sign("RS256", Buffer.from("My Message"));
+  const signResult = await cryptographyClient.sign("RS256", Buffer.from("My 32 bytes, to sign with RS256."));
   console.log("sign result: ", signResult.result);
 }
 


### PR DESCRIPTION
Hi hi! I wonder where else this could have slipped through! 🙏 any help appreciated.

The sign example in the PR changes uses RS256, which expects a message of at least 32 bytes. This sample exists in a section called "Sign Data", so seems like the correct solution is to switch to the `signData` method, which doesn't have this limitation.

Spotted on the customer issue: https://github.com/Azure/azure-sdk-for-js/issues/12654

If everything is ok and this ends up merged:
Fixes https://github.com/Azure/azure-sdk-for-js/issues/12654