### PR TITLE
Update Service Bus service level readme

### DIFF
--- a/docs-ref-services/latest/service-bus.md
+++ b/docs-ref-services/latest/service-bus.md
@@ -14,28 +14,24 @@ ms.service: Service Bus
 
 # Azure Service Bus Modules for JavaScript
 
-Azure Service Bus is an asynchronous messaging cloud platform that enables you to send data between decoupled systems.
+[Azure Service Bus](https://azure.microsoft.com/services/service-bus/) is a highly-reliable cloud messaging service from Microsoft and a fully managed enterprise integration message broker.
 
-Learn more about [Azure Service Bus](https://docs.microsoft.com/azure/service-bus-messaging/service-bus-messaging-overview).
+## Libraries for resource management
 
-## Client package
-Use npm to install the Azure Service Bus module for JavaScript
+To manage your Azure Service Bus resources like namespaces, queues, topics, subscriptions and rules via the Azure Resource Manager, you would use the below package.
 
-```bash
-npm install @azure/service-bus
-```
+| NPM Package                                                              | Reference                                                                                                  |
+| ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| [@azure/arm-servicebus](https://npmjs.com/package/@azure/arm-servicebus) | [API Reference for @azure/arm-servicebus](https://docs.microsoft.com/javascript/api/@azure/arm-servicebus) |
 
-See the reference documentation for this package [here](https://docs.microsoft.com/javascript/api/@azure/service-bus/?view=azure-node-latest) or the readme for the package [here](https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/servicebus/service-bus/README.md).
+## Libraries for data access
 
-For more code samples that use the @azure/service-bus package, explore the [JavaScript samples](https://docs.microsoft.com/samples/browse/?languages=javascript&products=azure-service-bus) or the [TypeScript samples](https://docs.microsoft.com/samples/browse/?languages=typescript&products=azure-service-bus).
+To send and receive messages from an Azure Service Bus queue, topic or subscription, you would use the below package.
+This also allows to manage your Azure Service Bus resources like queues, topics, subscriptions and rules, but not the namespace itself.
 
-## Management package
-Use npm to install the Azure Service Bus module for JavaScript
+| NPM Package                                                        | Reference                                                                                            | Samples                                                                                                                              |
+| ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| [@azure/service-bus](https://npmjs.com/package/@azure/service-bus) | [API Reference for @azure/service-bus](https://docs.microsoft.com/javascript/api/@azure/service-bus) | [Samples for sending & receiving messages](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/samples) |
 
-```bash
-npm install @azure/arm-servicebus
-```
-
-See the documentation for this package [here](https://docs.microsoft.com/javascript/api/overview/azure/servicebus/management?view=azure-node-latest).
 
 Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-servicebus)

--- a/docs-ref-services/latest/service-bus.md
+++ b/docs-ref-services/latest/service-bus.md
@@ -26,12 +26,30 @@ To manage your Azure Service Bus resources like namespaces, queues, topics, subs
 
 ## Libraries for data access
 
-To send and receive messages from an Azure Service Bus queue, topic or subscription, you would use the below package.
+### v7 of @azure/service-bus
+
+To send and receive messages from an Azure Service Bus queue, topic or subscription, you would use the latest version of the `@azure/service-bus` package.
 This also allows to manage your Azure Service Bus resources like queues, topics, subscriptions and rules, but not the namespace itself.
 
 | NPM Package                                                        | Reference                                                                                            | Samples                                                                                                                              |
 | ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| [@azure/service-bus](https://npmjs.com/package/@azure/service-bus) | [API Reference for @azure/service-bus](https://docs.microsoft.com/javascript/api/@azure/service-bus) | [Samples for sending & receiving messages](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/samples) |
+| [@azure/service-bus v7](https://npmjs.com/package/@azure/service-bus) | [API Reference for @azure/service-bus v7](https://docs.microsoft.com/javascript/api/@azure/service-bus) | [Samples for sending & receiving messages v7](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/servicebus/service-bus/samples) |
+
+### v1 of @azure/service-bus
+
+The older version of the `@azure/service-bus` package also allows you to send and receive messages from an Azure Service Bus queue, topic or subscription, but it lacks
+a lot of the new features and performance improvements available in the latest version of the same package.
+
+| NPM Package                                                        | Reference                                                                                            | Samples                                                                                                                              |
+| ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| [@azure/service-bus v1](https://www.npmjs.com/package/@azure/service-bus/v/1.1.10) | [API Reference for @azure/service-bus v1](https://docs.microsoft.com/en-us/javascript/api/@azure/service-bus/?view=azure-node-legacy) | [Samples for sending & receiving messages v1](https://github.com/Azure/azure-sdk-for-js/tree/%40azure/service-bus_1.1.10/sdk/servicebus/service-bus/samples) |
+
+### v1 of azure-sb
+
+There is a much older package `azure-sb` that allows you to send and receive messages from an Azure Service Bus queue, topic or subscription. Unlike the newer `@azure/service-bus` package that uses the faster AMQP proptocol, this package uses the slower HTTP protocol. Though it also allows you to manage the Azure Service Bus resources like queues, topics, subscriptions and rules, this package is not in active development
+
+| NPM Package                                                        | Reference                                                                                            | Samples                                                                                                                              |
+| ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| [azure-sb](https://npmjs.com/package/azure-sb) | [API Reference for azure-sb](https://docs.microsoft.com/en-us/javascript/api/azure-sb/?view=azure-node-legacy) | [Samples for sending & receiving messages](https://www.npmjs.com/package/azure-sb#how-to-use) |
 
 
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-servicebus)


### PR DESCRIPTION
The page https://github.com/MicrosoftDocs/azure-docs-sdk-node/blob/c67e75cb905ec431387183157a82ca96fbedfa80/docs-ref-services/latest/service-bus.md powers the content in https://docs.microsoft.com/en-us/javascript/api/overview/azure/service-bus?view=azure-node-latest

This PR updates it to match with what is in the azure-sdk-for-js repo for Service Bus i.e. https://github.com/azure/azure-sdk-for-js/blob/master/sdk/servicebus/README.md and follow the guidelines to add pointers to older package versions
