### PR TITLE
Update Key Vault service level readme

### DIFF
--- a/docs-ref-services/latest/key-vault-index.md
+++ b/docs-ref-services/latest/key-vault-index.md
@@ -14,28 +14,48 @@ ms.service: key-vault
 
 # Azure Key Vault modules for JavaScript
 
-The Azure Key Vault libraries for JavaScript offer a convenient interface for making calls to Azure Key Vault. For more information about Azure Key Vault, see [Introduction to Azure Key Vault](https://docs.microsoft.com/azure/key-vault/general/overview).
+# Azure Key Vault client libraries for for JavaScript
 
-## Libraries for data access
-
-The latest version of the Azure Key Vault library is version 4.x.x. Microsoft recommends using version 4.x.x for new applications.
-
-### Version 4.x.x
-
-The version 4.x.x libraries for JavaScript are part of the Azure SDK for JavaScript. The source code for the Key Vault libraries for JavaScript is available on [GitHub](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault).
-
-Use the following version 4.x.x libraries to work with certificates, keys, and secrets:
-
-| Library | Reference | Package | Source |
-|----------------------------------------|-------------------------------------------------------------|-----------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
-|    keyvault-certificates    |      [Reference](https://docs.microsoft.com/javascript/api/@azure/keyvault-certificates/?view=azure-node-latest)       |    [npm](https://www.npmjs.com/package/@azure/keyvault-certificates)    |    [GitHub](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-certificates)    |
-|    keyvault-keys    |     [Reference](https://docs.microsoft.com/javascript/api/@azure/keyvault-keys/?view=azure-node-latest)    |    [npm](https://www.npmjs.com/package/@azure/keyvault-keys)      |     [GitHub](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-keys)|
-|    keyvault-secrets   |    [Reference](https://docs.microsoft.com/javascript/api/@azure/keyvault-secrets/?view=azure-node-latest)    |    [npm](https://www.npmjs.com/package/@azure/keyvault-secrets)    |    [GitHub](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-secrets)    |
+[Azure Key Vault](https://azure.microsoft.com/services/key-vault/) is a Microsoft-managed service providing cloud keys, secrets, and certificate storage and utility that is highly available, secure, durable, scalable, and redundant.
 
 ## Libraries for resource management
 
-Use the following library to work with the Azure Key Vault resource provider:
+To manage your Azure Key Vault resources via the Azure Resource Manager, you would use the below package.
 
-| Library | Reference | Package | Source |
-|--------------------------------------|---------------------------------------------------------------|-------------------------------------------------------------------------------|-------------------------------------------------------------------------------|
-|    arm-keyvault    |    [Reference](https://docs.microsoft.com/javascript/api/@azure/arm-keyvault/?view=azure-node-latest)    |    [npm](https://www.npmjs.com/package/@azure/arm-keyvault)    |    [GitHub](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/arm-keyvault)    |
+| NPM Package                                                          | Reference                                                                                              |
+| -------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| [@azure/arm-keyvault](https://npmjs.com/package/@azure/arm-keyvault) | [API Reference for @azure/arm-keyvault](https://docs.microsoft.com/javascript/api/@azure/arm-keyvault) |
+
+## Libraries for data access
+
+There are three packages to work with Key Vault keys, secrets and certificates respectively.
+A fourth package, `@azure/keyvault-admin` (still in preview) is also available for administrative tasks on your Key Vault instance.
+
+| NPM Package                                                                            | Reference                                                                                                                | Samples                                                                                                                                   |
+| -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| [@azure/keyvault-keys](https://npmjs.com/package/@azure/keyvault-keys)                 | [API Reference for @azure/keyvault-keys](https://docs.microsoft.com/javascript/api/@azure/keyvault-keys)                 | [Samples for working with keys](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-keys/samples)                 |
+| [@azure/keyvault-secrets](https://npmjs.com/package/@azure/keyvault-secrets)           | [API Reference for @azure/keyvault-secrets](https://docs.microsoft.com/javascript/api/@azure/keyvault-secrets)           | [Samples for working with secrets](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-secrets/samples)           |
+| [@azure/keyvault-certificates](https://npmjs.com/package/@azure/keyvault-certificates) | [API Reference for @azure/keyvault-certificates](https://docs.microsoft.com/javascript/api/@azure/keyvault-certificates) | [Samples for working with certificates](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-certificates/samples) |
+| [@azure/keyvault-admin](https://npmjs.com/package/@azure/keyvault-admin) (in Preview)  | [API Reference for @azure/keyvault-admin](https://docs.microsoft.com/javascript/api/@azure/keyvault-admin)               | [Samples for administrative tasks](https://github.com/Azure/azure-sdk-for-js/tree/master/sdk/keyvault/keyvault-admin/samples)             |
+
+These packages have the below features:
+
+- Key Vault Keys
+  - Create keys using elliptic curve or RSA encryption, optionally backed by Hardware Security Modules (HSM).
+  - Import, delete and update keys.
+  - Get one or more keys and deleted keys.
+  - Recover a deleted key and restore a backed up key.
+  - Get the versions and the attributes of a key.
+  - Encrypting, decrypting, signing, verifying, wrapping and unwrapping data with keys.
+- Key Vault Secrets
+  - Get, set and delete a secret.
+  - Update a secret and it's attributes.
+  - Backup and restore a secret.
+  - Get, purge or recover a deleted secret.
+  - Get all the versions of a secret, or secrets, or deleted secrets.
+- Key Vault Certificates
+  - Get, set and delete a certificate.
+  - Update a certificate, its attributes, issuer, policy, operation and contacts.
+  - Backup and restore a certificate.
+  - Get, purge or recover a deleted certificate.
+  - Get all the versions of a certificate, or certificates, or deleted certificates.


### PR DESCRIPTION
The page https://github.com/MicrosoftDocs/azure-docs-sdk-node/blob/c67e75cb905ec431387183157a82ca96fbedfa80/docs-ref-services/latest/key-vault-index.md powers the content in https://docs.microsoft.com/en-us/javascript/api/overview/azure/key-vault-index?view=azure-node-latest

This PR updates it to match with what is in the azure-sdk-for-js repo for Key Vault i.e. https://github.com/azure/azure-sdk-for-js/blob/master/sdk/keyvault/README.md