### PR TITLE
Add azure-arm-eventhub to packages-legacy

### DIFF
--- a/ci-configs/packages-legacy.json
+++ b/ci-configs/packages-legacy.json
@@ -38,6 +38,9 @@
         {
             "name": "azure-storage",
             "folder": "./typings/azure-storage"
+        },
+        {
+            "name": "azure-arm-eventhub"
         }
     ]
 }


### PR DESCRIPTION
Testing to see if adding an entry to packages-legacy file is enough to make the ref docs appear in the legacy moniker

cc @scbedd, @danieljurek 