### PR TITLE
Update the landing page for Event Grid

### DIFF
--- a/docs-ref-services/latest/eventgrid.md
+++ b/docs-ref-services/latest/eventgrid.md
@@ -19,108 +19,43 @@ Build event-driven applications that listen and react to events from Azure servi
 
 [Learn more](/azure/event-grid/overview) about Azure Event Grid and get started with the [Azure Blob storage event tutorial](/azure/storage/blobs/storage-blob-event-quickstart). 
 
-## Publish SDK
+## Libraries for resource management
 
-Create events, authenticate, and post to topics using the Azure Event Grid publish SDK.
+To manage your Azure Event Grid resources like Event Grid instances, topics, and subscriptions via the Azure Resource Manager, you would use the below package.
 
-### Installation
+| NPM Package                                                              | Reference                                                                                                  |
+| ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| [@azure/arm-eventgrid](https://npmjs.com/package/@azure/arm-eventgrid) | [API Reference for @azure/arm-eventgrid](https://docs.microsoft.com/javascript/api/@azure/arm-eventgrid) |
 
-Add the module to your project with npm:
+## Libraries for data access
 
-```bash
-npm install azure-eventgrid
-```
+Create events, authenticate, and post to topics using the below packages
 
-### Example code
+### v2 of @azure/eventgrid
 
-The following code segment publishes a mock event to a Event Grid topic. You can retrieve the endpoint and topic access keys from the Azure Portal or through the Azure CLI:
+To create events, authenticate, and post to topics, you would use the `@azure/eventgrid` package.
 
-```azurecli-interactive
-endpoint=$(az eventgrid topic show --name <topic_name> -g gridResourceGroup --query "endpoint" --output tsv)
-key=$(az eventgrid topic key list --name <topic_name> -g gridResourceGroup --query "key1" --output tsv)
-```
+| NPM Package                                                        | Reference                                                                                            |   
+| ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- | 
+| [@azure/eventgrid v2](https://npmjs.com/package/@azure/eventgrid) | [API Reference for @azure/eventgrid v2](https://docs.microsoft.com/javascript/api/@azure/eventgrid) | 
 
-```JavaScript
-var EventGridClient = require("azure-eventgrid");
-var msRestAzure = require('ms-rest-azure');
-var uuid = require('uuid').v4;
-var url = require('url');
+### v3 of @azure/eventgrid (in preview)
 
-let topicCreds = new msRestAzure.TopicCredentials('your-topic-key');
-let EGClient = new EventGridClient(topicCreds, 'your-subscription-id');
-let topicEndpoint = 'your-topic-endpoint';
-let topicUrl = url.parse(topicEndpoint, true);
-let topicHostName = topicUrl.host;
+To create events, authenticate, and post to topics, you can also try latest version of the `@azure/eventgrid` i.e. v3. Since this version is still in preview, we do not recommend using this in your production environment until we release a stable version.
 
-let events = [
-   {
-   id: uuid(),
-   subject: 'TestSubject',
-   dataVersion: '1.0',
-   eventType: 'Microsoft.MockPublisher.TestEvent',
-   data: {
-        field1: 'value1',
-        filed2: 'value2'
-        }
-    }
-];
-return EGClient.publishEvents(topicHostName, events).then((result) => {
-   return Promise.resolve(console.log('Published events successfully.'));
- }).catch((err) => {
-  console.log('An error ocurred');
-  console.dir(err, {depth: null, colors: true});
-});
-```
+| NPM Package                                                        | Reference                                                                                            |   
+| ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- | 
+| [@azure/eventgrid v3](https://www.npmjs.com/package/@azure/eventgrid/v/next) | [API Reference for @azure/eventgrid v3](https://docs.microsoft.com/en-us/javascript/api/@azure/eventgrid/?view=azure-node-preview) | 
 
-This sample shows how to handle an event from Azure Storage:
 
-```JavaScript
-var http = require('http');
+### v1 of azure-eventgrid
 
-module.exports = function (context, req) {
-    context.log('JavaScript HTTP trigger function begun');
-    var validationEventType = "Microsoft.EventGrid.SubscriptionValidationEvent";
-    var storageBlobCreatedEvent = "Microsoft.Storage.BlobCreated";
+To create events, authenticate, and post to topics, you can use the older `azure-event-grid` package as well. Since this package will only receive critical bug fixes and no new features, we recommend using the latest `@azure/eventgrid` instead
 
-    for (var events in req.body) {
-        var body = req.body[events];
-        // Deserialize the event data into the appropriate type based on event type  
-        if (body.data && body.eventType == validationEventType) {
-            context.log("Got SubscriptionValidation event data, validation code: " + body.data.validationCode + " topic: " + body.topic);
+| NPM Package                                                        | Reference                                                                                            | 
+| ------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------- | 
+| [azure-event-grid](https://npmjs.com/package/azure-event-grid) | [API Reference for azure-event-grid](https://docs.microsoft.com/javascript/api/azure-event-grid) | 
 
-            // Do any additional validation (as required) and then return back the below response
-            var code = body.data.validationCode;
-            context.res = { status: 200, body: { "ValidationResponse": code } };
-        }
-
-        else if (body.data && body.eventType == storageBlobCreatedEvent) {
-            var blobCreatedEventData = body.data;
-            context.log("Relaying received blob created event payload:" + JSON.stringify(blobCreatedEventData));
-        }
-    }
-    context.done();
-};
-```
-
-> [!div class="nextstepaction"]
-> [Explore the client APIs](/JavaScript/api/overview/azure/eventgrid/client)
-
-## Management SDK
-
-Create, update, or delete Event Grid instances, topics, and subscriptions with the management SDK.
-
-### Installation
-
-```
-npm install @azure/arm-eventgrid
-```
-
-### Samples
-
-Examples for using this module in Node.js as well as browser applications can be found in the [README for the module](https://www.npmjs.com/package/@azure/arm-eventgrid)
-
-> [!div class="nextstepaction"]
-> [Explore the management APIs](/https://www.npmjs.com/package/@azure/arm-eventgrid)
 
 ## Learn more
 


### PR DESCRIPTION
The landing page for services are meant to follow a template listing all applicable packages, their API References and samples.
This PR does the above except the samples part which we can add for the new version once it goes GA