### PR TITLE
Update packages-latest.json

### DIFF
--- a/ci-configs/packages-latest.json
+++ b/ci-configs/packages-latest.json
@@ -8,7 +8,7 @@
   "toc_groups": [
     {
       "tocGroup": "Key Vault",
-      "overviewMDPath": "/javascript/api/overview/azure/key-vault-index",
+      "overviewMDPath": "../docs-ref-services/latest/key-vault-index.md",
       "npmPackages": [
         {
           "name": "@azure/keyvault-certificates@latest"
@@ -23,7 +23,7 @@
     },
     {
       "tocGroup": "Storage",
-      "overviewMDPath": "/javascript/api/overview/azure/storage-index",
+      "overviewMDPath": "../docs-ref-services/latest/storage-index.md",
       "npmPackages": [
         {
           "name": "@azure/storage-queue@latest"
@@ -32,7 +32,7 @@
     },
     {
       "tocGroup": "Storage/Blob",
-      "overviewMDPath": "/javascript/api/overview/azure/storage-blob-readme",
+      "overviewMDPath": "../docs-ref-services/latest/storage-blob-readme.md",
       "npmPackages": [
         {
           "name": "@azure/storage-blob@latest"
@@ -41,7 +41,7 @@
     },
     {
       "tocGroup": "Storage/File",
-      "overviewMDPath": "/javascript/api/overview/azure/storage-file-share-readme",
+      "overviewMDPath": "../docs-ref-services/latest/storage-file-share-readme.md",
       "npmPackages": [
         {
           "name": "@azure/storage-file-share@latest"


### PR DESCRIPTION
On the filesystem, the TOC is generated in docs-ref-autogen . These paths make sure that when the TOC is written at rest on the repo the relative paths to the overview pages are consistent.