### PR TITLE
Generate docs for @azure/eventgrid@2.0.0 in legacy moniker

### DIFF
--- a/ci-configs/packages-legacy.json
+++ b/ci-configs/packages-legacy.json
@@ -35,6 +35,9 @@
         },
         {
             "name": "azure-arm-eventhub"
+        },
+        {
+            "name": "@azure/eventgrid@2.0.0"
         }
     ]
 }


### PR DESCRIPTION
Now that we've released @azure/eventgrid@4.0.0, move the older version
to the legacy monikor. This will allow us to continue to link to the older
API docs from our ToC.