### PR TITLE
Remove detected duplicates

### DIFF
--- a/ci-configs/packages-preview.json
+++ b/ci-configs/packages-preview.json
@@ -103,18 +103,6 @@
       "name": "@azure/web-pubsub-express@1.0.0-beta.1"
     },
     {
-      "name": "@azure/search-documents@11.2.0-beta.2"
-    },
-    {
-      "name": "@azure/container-registry@1.0.0-beta.2"
-    },
-    {
-      "name": "@azure/identity@2.0.0-beta.3"
-    },
-    {
-      "name": "@azure/monitor-opentelemetry-exporter@1.0.0-beta.3"
-    },
-    {
       "name": "microsoft-speech-browser-sdk"
     },
     {


### PR DESCRIPTION
These duplicates were added by older versions of onboarding automation. This PR removes them. While they don't break the build duplicates in the onboarding file may show up as multiple entries for the same package in the ToC. 

Also, before merging, I'll need to know what to do with `@azure/opentelemetry-exporter-azure-monitor` 