### PR TITLE
Remove the Core node

### DIFF
--- a/docs-ref-mapping/reference-unified.yml
+++ b/docs-ref-mapping/reference-unified.yml
@@ -458,18 +458,6 @@
         children:
         - azure-arm-containerservice
         - '@azure/arm-containerservice*'
-    - name: Core
-      uid: azure.nodejs.sdk.landingpage.services.core
-      href: ~/docs-ref-services/{moniker}/core-http-readme.md
-      children:
-      - '@azure/core-http'
-      - '@azure/core-amqp'
-      - '@azure/core-lro'
-      - '@azure/core-paging'
-      - '@azure/core-auth'
-      - '@azure/amqp-common'
-      - '@azure/core-tracing'
-      - '@azure/logger'
     - name: Cosmos DB
       uid: azure.nodejs.sdk.landingpage.services.cosmosdb
       href: ~/docs-ref-services/{moniker}/cosmos-db.md

--- a/docs-ref-mapping/reference.yml
+++ b/docs-ref-mapping/reference.yml
@@ -438,18 +438,6 @@
       children:
       - azure-arm-containerservice
       - '@azure/arm-containerservice*'
-  - name: Core
-    uid: azure.nodejs.sdk.landingpage.services.core
-    href: ~/docs-ref-services/latest/core-http-readme.md
-    children:
-    - '@azure/core-http'
-    - '@azure/core-amqp'
-    - '@azure/core-lro'
-    - '@azure/core-paging'
-    - '@azure/core-auth'
-    - '@azure/amqp-common'
-    - '@azure/core-tracing'
-    - '@azure/logger'
   - name: Cosmos DB
     uid: azure.nodejs.sdk.landingpage.services.cosmosdb
     href: ~/docs-ref-services/latest/cosmos-db.md


### PR DESCRIPTION
Removing the "Core" node from the TOC as per discussions in https://github.com/Azure/azure-sdk-for-js/issues/15905 as it does not correspond to any Azure service like the other nodes. Packages under it should start appearing under "Other"