### PR TITLE
Correct confusing ms number in expiresOn parameter for SAS links

### DIFF
--- a/docs-ref-autogen/@azure/storage-blob/index.yml
+++ b/docs-ref-autogen/@azure/storage-blob/index.yml
@@ -418,7 +418,7 @@ functions:
           containerName, // Required
           permissions: ContainerSASPermissions.parse("racwdl"), // Required
           startsOn: new Date(), // Optional
-          expiresOn: new Date(new Date().valueOf() + 86400), // Required. Date type
+          expiresOn: new Date(new Date().valueOf() + 86400 * 1000), // Required. Date type
           ipRange: { start: "0.0.0.0", end: "255.255.255.255" }, // Optional
           protocol: SASProtocol.HttpsAndHttp, // Optional
           version: "2016-05-31" // Optional
@@ -443,7 +443,7 @@ functions:
       await containerClient.setAccessPolicy(undefined, [
         {
           accessPolicy: {
-            expiresOn: new Date(new Date().valueOf() + 86400), // Date type
+            expiresOn: new Date(new Date().valueOf() + 86400 * 1000), // Date type
             permissions: ContainerSASPermissions.parse("racwdl").toString(),
             startsOn: new Date() // Date type
           },
@@ -475,7 +475,7 @@ functions:
           blobName, // Required
           permissions: BlobSASPermissions.parse("racwd"), // Required
           startsOn: new Date(), // Optional
-          expiresOn: new Date(new Date().valueOf() + 86400), // Required. Date type
+          expiresOn: new Date(new Date().valueOf() + 86400 * 1000), // Required. Date type
           cacheControl: "cache-control-override", // Optional
           contentDisposition: "content-disposition-override", // Optional
           contentEncoding: "content-encoding-override", // Optional


### PR DESCRIPTION
Within the documentation for the generation of blob SAS links, there is a expiry date that uses +86400 on new Date().valueOf() to calculate an expiry. I can only assume that the person who provided this example was intending on an expiry of 24 hrs, as 86400s / 60 / 60 = 24 hrs - however javascript date .valueOf uses milliseconds, so this number is actually only 1 minute and 26.4 seconds. This is confusing, in our case we had someone copy the snippet and consequently was confused when the SAS link was expiring so soon. 

We are now using date-fns to calculate our expiresOn date, but it makes sense to add * 1000 to this documentation to make it actually create a 24 hr expiry.

Thank you.