### PR TITLE
One stop mass update for author and ms.author

### DIFF
--- a/docs-ref-services/latest/abort-controller-readme.md
+++ b/docs-ref-services/latest/abort-controller-readme.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, javascript, SDK, API, @azure/abort-controller, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 03/04/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/ai-form-recognizer-readme.md
+++ b/docs-ref-services/latest/ai-form-recognizer-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Form Recognizer client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/ai-form-recognizer, formrecognizer
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/11/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/ai-metrics-advisor-readme.md
+++ b/docs-ref-services/latest/ai-metrics-advisor-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Metrics Advisor client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/ai-metrics-advisor, metricsadvisor
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 07/06/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/ai-text-analytics-readme.md
+++ b/docs-ref-services/latest/ai-text-analytics-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Text Analytics client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/ai-text-analytics, textanalytics
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 07/07/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/app-configuration-readme.md
+++ b/docs-ref-services/latest/app-configuration-readme.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, javascript, SDK, API, @azure/app-configuration, appconfiguration
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 07/29/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/attestation-readme.md
+++ b/docs-ref-services/latest/attestation-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Attestation client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/attestation, attestation
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/13/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/authorization.md
+++ b/docs-ref-services/latest/authorization.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Authorization modules for JavaScript
 description: Reference for Azure Authorization modules for JavaScript
-author: rloutlaw
-ms.author: ROutlaw
+author: ramya-rao-a
+ms.author: ramyar
 manager: angrobe
 ms.date: 07/18/2017
 ms.topic: reference

--- a/docs-ref-services/latest/commerce.md
+++ b/docs-ref-services/latest/commerce.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Commerce modules for JavaScript
 description: Reference for Azure Commerce modules for JavaScript
-author: rloutlaw
-ms.author: ROutlaw
+author: ramya-rao-a
+ms.author: ramyar
 manager: angrobew
 ms.date: 07/18/2017
 ms.topic: reference

--- a/docs-ref-services/latest/communication-chat-readme.md
+++ b/docs-ref-services/latest/communication-chat-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Communication Chat client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/communication-chat, communication
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/20/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/communication-common-readme.md
+++ b/docs-ref-services/latest/communication-common-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Communication Common client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/communication-common, communication
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 07/23/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/communication-identity-readme.md
+++ b/docs-ref-services/latest/communication-identity-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Communication Identity client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/communication-identity, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 03/29/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/communication-phone-numbers-readme.md
+++ b/docs-ref-services/latest/communication-phone-numbers-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Communication Phone Numbers client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/communication-phone-numbers, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 04/26/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/communication-sms-readme.md
+++ b/docs-ref-services/latest/communication-sms-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Communication SMS client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/communication-sms, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 03/29/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/core-amqp-readme.md
+++ b/docs-ref-services/latest/core-amqp-readme.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, javascript, SDK, API, @azure/core-amqp, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 06/09/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/core-auth-readme.md
+++ b/docs-ref-services/latest/core-auth-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Core Authentication client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/core-auth, core
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 07/01/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/core-client-readme.md
+++ b/docs-ref-services/latest/core-client-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Core Service client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/core-client, core
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/25/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/core-http-readme.md
+++ b/docs-ref-services/latest/core-http-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Core HTTP client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/core-http, core
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/03/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/core-lro-readme.md
+++ b/docs-ref-services/latest/core-lro-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Core LRO client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/core-lro, core
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/30/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/core-paging-readme.md
+++ b/docs-ref-services/latest/core-paging-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Core Paging client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/core-paging, core
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/31/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/core-rest-pipeline-readme.md
+++ b/docs-ref-services/latest/core-rest-pipeline-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Core HTTP client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/core-rest-pipeline, core
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/04/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/core-xml-readme.md
+++ b/docs-ref-services/latest/core-xml-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Core XML client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/core-xml, core
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/06/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/cosmos-readme.md
+++ b/docs-ref-services/latest/cosmos-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Cosmos DB client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/cosmos, cosmosdb
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/02/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/data-tables-readme.md
+++ b/docs-ref-services/latest/data-tables-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Tables client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/data-tables, tables
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/07/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/digital-twins-core-readme.md
+++ b/docs-ref-services/latest/digital-twins-core-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Azure Digital Twins Core client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/digital-twins-core, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 01/15/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/event-hubs-readme.md
+++ b/docs-ref-services/latest/event-hubs-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Event Hubs client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/event-hubs, eventhubs
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 07/07/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/eventgrid-readme.md
+++ b/docs-ref-services/latest/eventgrid-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Event Grid client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/eventgrid, eventgrid
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/05/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/eventgrid.md
+++ b/docs-ref-services/latest/eventgrid.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Event Grid libraries for JavaScript
 description: Reference for Azure Event Grid libraries for JavaScript
-author: rloutlaw 
-ms.author: routlaw    
+author: ramya-rao-a
+ms.author: ramyar
 manager: angerobe
 ms.date: 05/03/2018
 ms.topic: reference

--- a/docs-ref-services/latest/eventhubs-checkpointstore-blob-readme.md
+++ b/docs-ref-services/latest/eventhubs-checkpointstore-blob-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Event Hubs Checkpoint Store library for Javascript
 keywords: Azure, javascript, SDK, API, @azure/eventhubs-checkpointstore-blob, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/03/2020
 ms.topic: reference
 ms.devlang: javascript

--- a/docs-ref-services/latest/identity-cache-persistence-readme.md
+++ b/docs-ref-services/latest/identity-cache-persistence-readme.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, javascript, SDK, API, @azure/identity-cache-persistence, identity
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/16/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/identity-readme.md
+++ b/docs-ref-services/latest/identity-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Identity client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/identity, identity
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/28/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/identity-vscode-readme.md
+++ b/docs-ref-services/latest/identity-vscode-readme.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, javascript, SDK, API, @azure/identity-vscode, identity
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/16/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/key-vault/keyvault-certificates-readme.md
+++ b/docs-ref-services/latest/key-vault/keyvault-certificates-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Key Vault Certificates client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/keyvault-certificates, keyvault
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 07/29/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/key-vault/keyvault-keys-readme.md
+++ b/docs-ref-services/latest/key-vault/keyvault-keys-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Key Vault Key client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/keyvault-keys, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 07/29/2021
 ms.topic: article
 ms.prod: azure

--- a/docs-ref-services/latest/key-vault/keyvault-secrets-readme.md
+++ b/docs-ref-services/latest/key-vault/keyvault-secrets-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Key Vault Secret client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/keyvault-secrets, keyvault
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 07/29/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/keyvault-admin-readme.md
+++ b/docs-ref-services/latest/keyvault-admin-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Key Vault Administration client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/keyvault-admin, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 07/29/2021
 ms.topic: article
 ms.prod: azure

--- a/docs-ref-services/latest/keyvault-certificates-readme.md
+++ b/docs-ref-services/latest/keyvault-certificates-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Key Vault Certificates client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/keyvault-certificates, keyvault
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 07/29/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/keyvault-keys-readme.md
+++ b/docs-ref-services/latest/keyvault-keys-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Key Vault Key client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/keyvault-keys, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 07/29/2021
 ms.topic: article
 ms.prod: azure

--- a/docs-ref-services/latest/keyvault-secrets-readme.md
+++ b/docs-ref-services/latest/keyvault-secrets-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Key Vault Secret client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/keyvault-secrets, keyvault
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 07/29/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/logger-readme.md
+++ b/docs-ref-services/latest/logger-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Logger client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/logger, core
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/30/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/monitor-query-readme.md
+++ b/docs-ref-services/latest/monitor-query-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Monitor Query client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/monitor-query, monitor
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/07/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/notification-hubs.md
+++ b/docs-ref-services/latest/notification-hubs.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Notification Hubs modules for JavaScript
 description: Reference for Azure Notification Hubs modules for JavaScript
-author: rloutlaw
-ms.author: ROutlaw
+author: ramya-rao-a
+ms.author: ramyar
 manager: angrobe
 ms.date: 07/18/2017
 ms.topic: reference

--- a/docs-ref-services/latest/scheduler.md
+++ b/docs-ref-services/latest/scheduler.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Scheduler modules for JavaScript
 description: Reference for Azure Scheduler modules for JavaScript
-author: rloutlaw
-ms.author: ROutlaw
+author: ramya-rao-a
+ms.author: ramyar
 manager: angrobe
 ms.date: 07/18/2017
 ms.topic: reference

--- a/docs-ref-services/latest/search-documents-readme.md
+++ b/docs-ref-services/latest/search-documents-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Cognitive Search client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/search-documents, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/07/2021
 ms.topic: article
 ms.prod: azure

--- a/docs-ref-services/latest/server-management.md
+++ b/docs-ref-services/latest/server-management.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Server Management modules for JavaScript
 description: Reference for Azure Server Management modules for JavaScript
-author: rloutlaw
-ms.author: ROutlaw
+author: ramya-rao-a
+ms.author: ramyar
 manager: angrobe
 ms.date: 07/18/2017
 ms.topic: reference

--- a/docs-ref-services/latest/service-bus-readme.md
+++ b/docs-ref-services/latest/service-bus-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Service Bus client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/service-bus, servicebus
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 07/07/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/storage-blob-readme.md
+++ b/docs-ref-services/latest/storage-blob-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage Blob client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/storage-blob, storage
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/10/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/storage-file-datalake-readme.md
+++ b/docs-ref-services/latest/storage-file-datalake-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage File Data Lake client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/storage-file-datalake, datalakestorage(gen2)
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/10/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/storage-file-share-readme.md
+++ b/docs-ref-services/latest/storage-file-share-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage File Share client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/storage-file-share, storage
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/10/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/storage-fileshare-readme.md
+++ b/docs-ref-services/latest/storage-fileshare-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Files for JavaScript Readme
 description: Reference for Azure Storage modules for JavaScript
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 manager: twolley
 ms.date: 03/12/2020
 ms.topic: reference

--- a/docs-ref-services/latest/storage-overview.md
+++ b/docs-ref-services/latest/storage-overview.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage modules for JavaScript
 description: Reference for Azure Storage modules for JavaScript
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 manager: twolley
 ms.date: 02/27/2020
 ms.topic: reference

--- a/docs-ref-services/latest/storage-queue-readme.md
+++ b/docs-ref-services/latest/storage-queue-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage Queue client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/storage-queue, storage
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/10/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/storage/storage-blob-readme.md
+++ b/docs-ref-services/latest/storage/storage-blob-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage Blob client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/storage-blob, storage
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/10/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/storage/storage-file-datalake-readme.md
+++ b/docs-ref-services/latest/storage/storage-file-datalake-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage File Data Lake client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/storage-file-datalake, datalakestorage(gen2)
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/10/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/storage/storage-file-share-readme.md
+++ b/docs-ref-services/latest/storage/storage-file-share-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage File Share client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/storage-file-share, storage
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/10/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/storage/storage-fileshare-readme.md
+++ b/docs-ref-services/latest/storage/storage-fileshare-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Files for JavaScript Readme
 description: Reference for Azure Storage modules for JavaScript
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 manager: twolley
 ms.date: 03/12/2020
 ms.topic: reference

--- a/docs-ref-services/latest/storage/storage-mgmt-overview.md
+++ b/docs-ref-services/latest/storage/storage-mgmt-overview.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage modules for JavaScript
 description: Reference for Azure Storage modules for JavaScript
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 manager: twolley
 ms.date: 02/27/2020
 ms.topic: reference

--- a/docs-ref-services/latest/storage/storage-overview.md
+++ b/docs-ref-services/latest/storage/storage-overview.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage SDK for JavaScript
 description: Reference for Azure Storage SDK for JavaScript
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 manager: twolley
 ms.date: 02/27/2020
 ms.topic: reference

--- a/docs-ref-services/latest/storage/storage-queue-readme.md
+++ b/docs-ref-services/latest/storage/storage-queue-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage Queue client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/storage-queue, storage
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/10/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/latest/template-readme.md
+++ b/docs-ref-services/latest/template-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Template client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/template, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 06/15/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/legacy/ai-form-recognizer-readme.md
+++ b/docs-ref-services/legacy/ai-form-recognizer-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Form Recognizer client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/ai-form-recognizer, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/20/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/legacy/ai-text-analytics-readme.md
+++ b/docs-ref-services/legacy/ai-text-analytics-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Text Analytics client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/ai-text-analytics, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/18/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/legacy/app-configuration-readme.md
+++ b/docs-ref-services/legacy/app-configuration-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Use App Configuration client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/app-configuration, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 07/07/2020
 ms.topic: reference
 ms.devlang: javascript

--- a/docs-ref-services/legacy/authorization.md
+++ b/docs-ref-services/legacy/authorization.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Authorization modules for JavaScript
 description: Reference for Azure Authorization modules for JavaScript
-author: rloutlaw
-ms.author: ROutlaw
+author: ramya-rao-a
+ms.author: ramyar
 manager: angrobe
 ms.date: 07/18/2017
 ms.topic: reference

--- a/docs-ref-services/legacy/commerce.md
+++ b/docs-ref-services/legacy/commerce.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Commerce modules for JavaScript
 description: Reference for Azure Commerce modules for JavaScript
-author: rloutlaw
-ms.author: ROutlaw
+author: ramya-rao-a
+ms.author: ramyar
 manager: angrobew
 ms.date: 07/18/2017
 ms.topic: reference

--- a/docs-ref-services/legacy/core-amqp-readme.md
+++ b/docs-ref-services/legacy/core-amqp-readme.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, javascript, SDK, API, @azure/core-amqp, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/12/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/legacy/core-auth-readme.md
+++ b/docs-ref-services/legacy/core-auth-readme.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, javascript, SDK, API, @azure/core-auth, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 06/30/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/legacy/core-http-readme.md
+++ b/docs-ref-services/legacy/core-http-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Core HTTP client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/core-http, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/06/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/legacy/core-paging-readme.md
+++ b/docs-ref-services/legacy/core-paging-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Core Paging client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/core-paging, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/30/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/legacy/cosmos-readme.md
+++ b/docs-ref-services/legacy/cosmos-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Cosmos DB client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/cosmos, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/09/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/legacy/digital-twins-core-readme.md
+++ b/docs-ref-services/legacy/digital-twins-core-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Azure Digital Twins Core client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/digital-twins-core, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/03/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/legacy/event-hubs-readme.md
+++ b/docs-ref-services/legacy/event-hubs-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Event Hubs client library for Javascript
 keywords: Azure, javascript, SDK, API, @azure/event-hubs, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 02/02/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/legacy/eventgrid.md
+++ b/docs-ref-services/legacy/eventgrid.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Event Grid libraries for JavaScript
 description: Reference for Azure Event Grid libraries for JavaScript
-author: rloutlaw 
-ms.author: routlaw    
+author: ramya-rao-a
+ms.author: ramyar
 manager: angerobe
 ms.date: 05/03/2018
 ms.topic: reference

--- a/docs-ref-services/legacy/eventhubs-checkpointstore-blob-readme.md
+++ b/docs-ref-services/legacy/eventhubs-checkpointstore-blob-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Event Hubs Checkpoint Store library for Javascript
 keywords: Azure, javascript, SDK, API, @azure/eventhubs-checkpointstore-blob, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/03/2020
 ms.topic: reference
 ms.devlang: javascript

--- a/docs-ref-services/legacy/identity-readme.md
+++ b/docs-ref-services/legacy/identity-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Identity client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/identity, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/11/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/legacy/key-vault/keyvault-certificates-readme.md
+++ b/docs-ref-services/legacy/key-vault/keyvault-certificates-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Key Vault Certificates client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/keyvault-certificates, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/12/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/legacy/key-vault/keyvault-keys-readme.md
+++ b/docs-ref-services/legacy/key-vault/keyvault-keys-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Key Vault Key client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/keyvault-keys, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/12/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/legacy/key-vault/keyvault-secrets-readme.md
+++ b/docs-ref-services/legacy/key-vault/keyvault-secrets-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Key Vault Secret client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/keyvault-secrets, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/12/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/legacy/keyvault-certificates-readme.md
+++ b/docs-ref-services/legacy/keyvault-certificates-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Key Vault Certificates client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/keyvault-certificates, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/12/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/legacy/keyvault-keys-readme.md
+++ b/docs-ref-services/legacy/keyvault-keys-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Key Vault Key client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/keyvault-keys, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/12/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/legacy/keyvault-secrets-readme.md
+++ b/docs-ref-services/legacy/keyvault-secrets-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Key Vault Secret client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/keyvault-secrets, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/12/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/legacy/notification-hubs.md
+++ b/docs-ref-services/legacy/notification-hubs.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Notification Hubs modules for JavaScript
 description: Reference for Azure Notification Hubs modules for JavaScript
-author: rloutlaw
-ms.author: ROutlaw
+author: ramya-rao-a
+ms.author: ramyar
 manager: angrobe
 ms.date: 07/18/2017
 ms.topic: reference

--- a/docs-ref-services/legacy/scheduler.md
+++ b/docs-ref-services/legacy/scheduler.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Scheduler modules for JavaScript
 description: Reference for Azure Scheduler modules for JavaScript
-author: rloutlaw
-ms.author: ROutlaw
+author: ramya-rao-a
+ms.author: ramyar
 manager: angrobe
 ms.date: 07/18/2017
 ms.topic: reference

--- a/docs-ref-services/legacy/search-documents-readme.md
+++ b/docs-ref-services/legacy/search-documents-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Cognitive Search client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/search-documents, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 07/31/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/legacy/server-management.md
+++ b/docs-ref-services/legacy/server-management.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Server Management modules for JavaScript
 description: Reference for Azure Server Management modules for JavaScript
-author: rloutlaw
-ms.author: ROutlaw
+author: ramya-rao-a
+ms.author: ramyar
 manager: angrobe
 ms.date: 07/18/2017
 ms.topic: reference

--- a/docs-ref-services/legacy/service-bus-readme.md
+++ b/docs-ref-services/legacy/service-bus-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Service Bus client library for Javascript
 keywords: Azure, , SDK, API, @azure/service-bus, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/23/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/legacy/storage-blob-readme.md
+++ b/docs-ref-services/legacy/storage-blob-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage Blob client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/storage-blob, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/11/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/legacy/storage-file-datalake-readme.md
+++ b/docs-ref-services/legacy/storage-file-datalake-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage File Data Lake client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/storage-file-datalake, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/11/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/legacy/storage-file-share-readme.md
+++ b/docs-ref-services/legacy/storage-file-share-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage File Share client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/storage-file-share, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/11/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/legacy/storage-fileshare-readme.md
+++ b/docs-ref-services/legacy/storage-fileshare-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Files for JavaScript Readme
 description: Reference for Azure Storage modules for JavaScript
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 manager: twolley
 ms.date: 03/12/2020
 ms.topic: reference

--- a/docs-ref-services/legacy/storage-overview.md
+++ b/docs-ref-services/legacy/storage-overview.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage modules for JavaScript
 description: Reference for Azure Storage modules for JavaScript
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 manager: twolley
 ms.date: 02/27/2020
 ms.topic: reference

--- a/docs-ref-services/legacy/storage-queue-readme.md
+++ b/docs-ref-services/legacy/storage-queue-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage Queue client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/storage-queue, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/11/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/legacy/storage/storage-blob-readme.md
+++ b/docs-ref-services/legacy/storage/storage-blob-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage Blob client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/storage-blob, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/11/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/legacy/storage/storage-file-datalake-readme.md
+++ b/docs-ref-services/legacy/storage/storage-file-datalake-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage File Data Lake client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/storage-file-datalake, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/11/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/legacy/storage/storage-file-share-readme.md
+++ b/docs-ref-services/legacy/storage/storage-file-share-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage File Share client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/storage-file-share, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/11/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/legacy/storage/storage-fileshare-readme.md
+++ b/docs-ref-services/legacy/storage/storage-fileshare-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Files for JavaScript Readme
 description: Reference for Azure Storage modules for JavaScript
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 manager: twolley
 ms.date: 03/12/2020
 ms.topic: reference

--- a/docs-ref-services/legacy/storage/storage-overview.md
+++ b/docs-ref-services/legacy/storage/storage-overview.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage SDK for JavaScript
 description: Reference for Azure Storage SDK for JavaScript
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 manager: twolley
 ms.date: 02/27/2020
 ms.topic: reference

--- a/docs-ref-services/legacy/storage/storage-queue-readme.md
+++ b/docs-ref-services/legacy/storage/storage-queue-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage Queue client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/storage-queue, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/11/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/ai-anomaly-detector-readme.md
+++ b/docs-ref-services/preview/ai-anomaly-detector-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Anomaly Detector client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/ai-anomaly-detector, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 04/17/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/ai-form-recognizer-readme.md
+++ b/docs-ref-services/preview/ai-form-recognizer-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Form Recognizer client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/ai-form-recognizer, formrecognizer
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/07/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/ai-metrics-advisor-readme.md
+++ b/docs-ref-services/preview/ai-metrics-advisor-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Metrics Advisor client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/ai-metrics-advisor, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 06/08/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/ai-text-analytics-readme.md
+++ b/docs-ref-services/preview/ai-text-analytics-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Text Analytics client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/ai-text-analytics, textanalytics
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/02/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/app-configuration-readme.md
+++ b/docs-ref-services/preview/app-configuration-readme.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, javascript, SDK, API, @azure/app-configuration, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 06/08/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-apimanagement-readme.md
+++ b/docs-ref-services/preview/arm-apimanagement-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure ApiManagement client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-apimanagement, apimanagement
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/09/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-appplatform-readme.md
+++ b/docs-ref-services/preview/arm-appplatform-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure AppPlatformManagement client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-appplatform, appplatform
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/27/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-appservice-readme.md
+++ b/docs-ref-services/preview/arm-appservice-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure WebSiteManagement client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-appservice, appservice
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/15/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-authorization-readme.md
+++ b/docs-ref-services/preview/arm-authorization-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure AuthorizationManagement client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-authorization, authorization
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/15/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-compute-readme.md
+++ b/docs-ref-services/preview/arm-compute-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure ComputeManagement client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-compute, compute
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/18/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-containerregistry-readme.md
+++ b/docs-ref-services/preview/arm-containerregistry-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure ContainerRegistryManagement client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-containerregistry, containerregistry
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/05/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-containerservice-readme.md
+++ b/docs-ref-services/preview/arm-containerservice-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure ContainerService client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-containerservice, containerservice
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/27/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-databricks-readme.md
+++ b/docs-ref-services/preview/arm-databricks-readme.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, javascript, SDK, API, @azure/arm-databricks, databricks
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/01/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-eventgrid-readme.md
+++ b/docs-ref-services/preview/arm-eventgrid-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure EventGridManagement client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-eventgrid, eventgrid
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/15/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-eventhub-readme.md
+++ b/docs-ref-services/preview/arm-eventhub-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure EventHubManagement client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-eventhub, eventhubs
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/15/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-extendedlocation-readme.md
+++ b/docs-ref-services/preview/arm-extendedlocation-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure customLocationsManagement client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-extendedlocation, extendedlocation
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/08/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-features-readme.md
+++ b/docs-ref-services/preview/arm-features-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Feature client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-features, features
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/15/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-keyvault-readme.md
+++ b/docs-ref-services/preview/arm-keyvault-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure KeyVaultManagement client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-keyvault, keyvault
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/15/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-links-readme.md
+++ b/docs-ref-services/preview/arm-links-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure ManagementLink client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-links, links
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/15/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-locks-readme.md
+++ b/docs-ref-services/preview/arm-locks-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure ManagementLock client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-locks, locks
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/15/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-logic-readme.md
+++ b/docs-ref-services/preview/arm-logic-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure LogicManagement client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-logic, logic
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/25/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-managedapplications-readme.md
+++ b/docs-ref-services/preview/arm-managedapplications-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Application client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-managedapplications, managedapplications
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/15/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-mediaservices-readme.md
+++ b/docs-ref-services/preview/arm-mediaservices-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Media client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-mediaservices, mediaservices
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/29/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-network-readme.md
+++ b/docs-ref-services/preview/arm-network-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure NetworkManagement client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-network, virtualnetwork
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/02/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-notificationhubs-readme.md
+++ b/docs-ref-services/preview/arm-notificationhubs-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure NotificationHubsManagement client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-notificationhubs, notificationhubs
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/01/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-operationalinsights-readme.md
+++ b/docs-ref-services/preview/arm-operationalinsights-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure OperationalInsightsManagement client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-operationalinsights, operationalinsights
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/15/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-operations-readme.md
+++ b/docs-ref-services/preview/arm-operations-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure OperationsManagement client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-operations, operationsmanagement
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/28/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-policy-readme.md
+++ b/docs-ref-services/preview/arm-policy-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Policy client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-policy, policy
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/18/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-postgresql-readme.md
+++ b/docs-ref-services/preview/arm-postgresql-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure PostgreSQLManagement client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-postgresql, postgresql
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/20/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-purview-readme.md
+++ b/docs-ref-services/preview/arm-purview-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure PurviewManagement client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-purview, purview
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/10/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-quota-readme.md
+++ b/docs-ref-services/preview/arm-quota-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Service client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-quota, quota
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/02/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-recoveryservices-readme.md
+++ b/docs-ref-services/preview/arm-recoveryservices-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure RecoveryServices client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-recoveryservices, recoveryservices
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/26/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-rediscache-readme.md
+++ b/docs-ref-services/preview/arm-rediscache-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure RedisManagement client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-rediscache, rediscache
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/15/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-resources-readme.md
+++ b/docs-ref-services/preview/arm-resources-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure ResourceManagement client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-resources, resources
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/15/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-resources-subscriptions-readme.md
+++ b/docs-ref-services/preview/arm-resources-subscriptions-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Subscription client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-resources-subscriptions, resourcessubscriptions
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/20/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-security-readme.md
+++ b/docs-ref-services/preview/arm-security-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Service client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-security, security
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/15/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-servicebus-readme.md
+++ b/docs-ref-services/preview/arm-servicebus-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure ServiceBusManagement client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-servicebus, servicebus
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/15/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-servicefabric-readme.md
+++ b/docs-ref-services/preview/arm-servicefabric-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure ServiceFabricManagement client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-servicefabric, servicefabric
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/05/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-sql-readme.md
+++ b/docs-ref-services/preview/arm-sql-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure SqlManagement client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-sql, sql
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/15/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-storage-readme.md
+++ b/docs-ref-services/preview/arm-storage-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure StorageManagement client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-storage, storage
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/15/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-streamanalytics-readme.md
+++ b/docs-ref-services/preview/arm-streamanalytics-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Stream Analytics Management client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-streamanalytics, streamanalytics
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/02/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-template-readme.md
+++ b/docs-ref-services/preview/arm-template-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure IoTSpaces client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-template, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 06/25/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-templatespecs-readme.md
+++ b/docs-ref-services/preview/arm-templatespecs-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure TemplateSpecs client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-templatespecs, templatespecs
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/26/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-videoanalyzer-readme.md
+++ b/docs-ref-services/preview/arm-videoanalyzer-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Service client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-videoanalyzer, videoanalyzer
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/01/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/arm-webpubsub-readme.md
+++ b/docs-ref-services/preview/arm-webpubsub-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure WebPubSubManagement client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/arm-webpubsub, webpubsub
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/31/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/attestation-readme.md
+++ b/docs-ref-services/preview/attestation-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Attestation client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/attestation, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 06/16/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/authorization.md
+++ b/docs-ref-services/preview/authorization.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Authorization modules for JavaScript
 description: Reference for Azure Authorization modules for JavaScript
-author: rloutlaw
-ms.author: ROutlaw
+author: ramya-rao-a
+ms.author: ramyar
 manager: angrobe
 ms.date: 07/18/2017
 ms.topic: reference

--- a/docs-ref-services/preview/commerce.md
+++ b/docs-ref-services/preview/commerce.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Commerce modules for JavaScript
 description: Reference for Azure Commerce modules for JavaScript
-author: rloutlaw
-ms.author: ROutlaw
+author: ramya-rao-a
+ms.author: ramyar
 manager: angrobew
 ms.date: 07/18/2017
 ms.topic: reference

--- a/docs-ref-services/preview/communication-administration-readme.md
+++ b/docs-ref-services/preview/communication-administration-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Communication Administration client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/communication-administration, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/16/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/communication-chat-readme.md
+++ b/docs-ref-services/preview/communication-chat-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Communication Chat client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/communication-chat, communication
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/30/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/communication-common-readme.md
+++ b/docs-ref-services/preview/communication-common-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Communication Common client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/communication-common, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 03/10/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/communication-identity-readme.md
+++ b/docs-ref-services/preview/communication-identity-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Communication Identity client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/communication-identity, communication
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/29/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/communication-network-traversal-readme.md
+++ b/docs-ref-services/preview/communication-network-traversal-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Communication Network Traversal client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/communication-network-traversal, communication
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 07/20/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/communication-phone-numbers-readme.md
+++ b/docs-ref-services/preview/communication-phone-numbers-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Communication Phone Numbers client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/communication-phone-numbers, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 03/29/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/communication-sms-readme.md
+++ b/docs-ref-services/preview/communication-sms-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Communication SMS client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/communication-sms, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 03/10/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/container-registry-readme.md
+++ b/docs-ref-services/preview/container-registry-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Container Registry client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/container-registry, containerregistry
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/08/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/core-amqp-readme.md
+++ b/docs-ref-services/preview/core-amqp-readme.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, javascript, SDK, API, @azure/core-amqp, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/04/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/core-auth-readme.md
+++ b/docs-ref-services/preview/core-auth-readme.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, javascript, SDK, API, @azure/core-auth, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 06/30/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/core-client-paging-rest-readme.md
+++ b/docs-ref-services/preview/core-client-paging-rest-readme.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, javascript, SDK, API, @azure-rest/core-client-paging, core
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/06/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/core-client-readme.md
+++ b/docs-ref-services/preview/core-client-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Core Service client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/core-client, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 03/10/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/core-client-rest-readme.md
+++ b/docs-ref-services/preview/core-client-rest-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Rest Core client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure-rest/core-client, core
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/04/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/core-http-readme.md
+++ b/docs-ref-services/preview/core-http-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Core HTTP client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/core-http, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/06/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/core-https-readme.md
+++ b/docs-ref-services/preview/core-https-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Core HTTP client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/core-https, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 02/05/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/core-paging-readme.md
+++ b/docs-ref-services/preview/core-paging-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Core Paging client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/core-paging, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/30/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/core-rest-pipeline-readme.md
+++ b/docs-ref-services/preview/core-rest-pipeline-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Core HTTP client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/core-rest-pipeline, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 06/04/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/core-tracing-readme.md
+++ b/docs-ref-services/preview/core-tracing-readme.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, javascript, SDK, API, @azure/core-tracing, core
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 07/15/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/core-util-readme.md
+++ b/docs-ref-services/preview/core-util-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Core Util client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/core-util, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 05/07/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/core-xml-readme.md
+++ b/docs-ref-services/preview/core-xml-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Core XML client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/core-xml, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 02/05/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/cosmos-readme.md
+++ b/docs-ref-services/preview/cosmos-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Cosmos DB client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/cosmos, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 11/09/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/data-tables-readme.md
+++ b/docs-ref-services/preview/data-tables-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Tables client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/data-tables, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 05/18/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/digital-twins-core-readme.md
+++ b/docs-ref-services/preview/digital-twins-core-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Azure Digital Twins Core client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/digital-twins-core, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/27/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/digital-twins-readme.md
+++ b/docs-ref-services/preview/digital-twins-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Azure Digital Twins client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/digital-twins, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/08/2020
 ms.topic: reference
 ms.devlang: javascript

--- a/docs-ref-services/preview/event-hubs-readme.md
+++ b/docs-ref-services/preview/event-hubs-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Event Hubs client library for Javascript
 keywords: Azure, javascript, SDK, API, @azure/event-hubs, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 03/09/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/eventgrid-readme.md
+++ b/docs-ref-services/preview/eventgrid-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Event Grid client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/eventgrid, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 02/10/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/eventgrid.md
+++ b/docs-ref-services/preview/eventgrid.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Event Grid libraries for JavaScript
 description: Reference for Azure Event Grid libraries for JavaScript
-author: rloutlaw 
-ms.author: routlaw    
+author: ramya-rao-a
+ms.author: ramyar
 manager: angerobe
 ms.date: 05/03/2018
 ms.topic: reference

--- a/docs-ref-services/preview/eventhubs-checkpointstore-blob-readme.md
+++ b/docs-ref-services/preview/eventhubs-checkpointstore-blob-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Event Hubs Checkpoint Store library for Javascript
 keywords: Azure, javascript, SDK, API, @azure/eventhubs-checkpointstore-blob, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/03/2020
 ms.topic: reference
 ms.devlang: javascript

--- a/docs-ref-services/preview/identity-cache-persistence-readme.md
+++ b/docs-ref-services/preview/identity-cache-persistence-readme.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, javascript, SDK, API, @azure/identity-cache-persistence, identity
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/10/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/identity-readme.md
+++ b/docs-ref-services/preview/identity-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Identity client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/identity, identity
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/10/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/identity-vscode-readme.md
+++ b/docs-ref-services/preview/identity-vscode-readme.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, javascript, SDK, API, @azure/identity-vscode, identity
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/10/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/iot-device-update-readme.md
+++ b/docs-ref-services/preview/iot-device-update-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Device Update for IoT Hub client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/iot-device-update, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 03/04/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/iot-modelsrepository-readme.md
+++ b/docs-ref-services/preview/iot-modelsrepository-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure IoT Models Repository client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/iot-modelsrepository, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 05/28/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/key-vault/keyvault-admin-readme.md
+++ b/docs-ref-services/preview/key-vault/keyvault-admin-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Key Vault Administration client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/keyvault-admin, keyvault
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/10/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/key-vault/keyvault-certificates-readme.md
+++ b/docs-ref-services/preview/key-vault/keyvault-certificates-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Key Vault Certificates client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/keyvault-certificates, keyvault
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/07/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/key-vault/keyvault-keys-readme.md
+++ b/docs-ref-services/preview/key-vault/keyvault-keys-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Key Vault Key client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/keyvault-keys, keyvault
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/10/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/key-vault/keyvault-secrets-readme.md
+++ b/docs-ref-services/preview/key-vault/keyvault-secrets-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Key Vault Secret client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/keyvault-secrets, keyvault
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/07/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/keyvault-admin-readme.md
+++ b/docs-ref-services/preview/keyvault-admin-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Key Vault Administration client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/keyvault-admin, keyvault
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/10/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/keyvault-certificates-readme.md
+++ b/docs-ref-services/preview/keyvault-certificates-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Key Vault Certificates client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/keyvault-certificates, keyvault
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/07/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/keyvault-keys-readme.md
+++ b/docs-ref-services/preview/keyvault-keys-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Key Vault Key client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/keyvault-keys, keyvault
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/05/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/keyvault-secrets-readme.md
+++ b/docs-ref-services/preview/keyvault-secrets-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Key Vault Secret client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/keyvault-secrets, keyvault
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/07/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/mixed-reality-authentication-readme.md
+++ b/docs-ref-services/preview/mixed-reality-authentication-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Mixed Reality Authentication client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/mixed-reality-authentication, mixedreality
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/21/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/mixed-reality-remote-rendering-readme.md
+++ b/docs-ref-services/preview/mixed-reality-remote-rendering-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Remote Rendering client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/mixed-reality-remote-rendering, remoterendering
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/21/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/monitor-opentelemetry-exporter-readme.md
+++ b/docs-ref-services/preview/monitor-opentelemetry-exporter-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Monitor OpenTelemetry Exporter client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/monitor-opentelemetry-exporter, monitor
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/05/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/monitor-query-readme.md
+++ b/docs-ref-services/preview/monitor-query-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Monitor Workspace query client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/monitor-query, monitor
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/10/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/notification-hubs.md
+++ b/docs-ref-services/preview/notification-hubs.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Notification Hubs modules for JavaScript
 description: Reference for Azure Notification Hubs modules for JavaScript
-author: rloutlaw
-ms.author: ROutlaw
+author: ramya-rao-a
+ms.author: ramyar
 manager: angrobe
 ms.date: 07/18/2017
 ms.topic: reference

--- a/docs-ref-services/preview/opentelemetry-exporter-azure-monitor-readme.md
+++ b/docs-ref-services/preview/opentelemetry-exporter-azure-monitor-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Monitor OpenTelemetry Exporter client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/opentelemetry-exporter-azure-monitor, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 01/20/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/purview-account-rest-readme.md
+++ b/docs-ref-services/preview/purview-account-rest-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Purview Account REST client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure-rest/purview-account, purview
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/01/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/purview-administration-rest-readme.md
+++ b/docs-ref-services/preview/purview-administration-rest-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Purview Administration REST client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure-rest/purview-administration, purview
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/15/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/purview-catalog-rest-readme.md
+++ b/docs-ref-services/preview/purview-catalog-rest-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Purview Catalog REST client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure-rest/purview-catalog, purview
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/15/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/purview-scanning-rest-readme.md
+++ b/docs-ref-services/preview/purview-scanning-rest-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Purview Scanning Rest-Level client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure-rest/purview-scanning, purview
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/15/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/quantum-jobs-readme.md
+++ b/docs-ref-services/preview/quantum-jobs-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Quantum Jobs client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/quantum-jobs, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 02/05/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/scheduler.md
+++ b/docs-ref-services/preview/scheduler.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Scheduler modules for JavaScript
 description: Reference for Azure Scheduler modules for JavaScript
-author: rloutlaw
-ms.author: ROutlaw
+author: ramya-rao-a
+ms.author: ramyar
 manager: angrobe
 ms.date: 07/18/2017
 ms.topic: reference

--- a/docs-ref-services/preview/schema-registry-avro-readme.md
+++ b/docs-ref-services/preview/schema-registry-avro-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Schema Registry Avro serializer client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/schema-registry-avro, schemaregistry
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/05/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/schema-registry-readme.md
+++ b/docs-ref-services/preview/schema-registry-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Schema Registry client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/schema-registry, schemaregistry
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/05/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/search-documents-readme.md
+++ b/docs-ref-services/preview/search-documents-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Cognitive Search client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/search-documents, search
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/05/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/server-management.md
+++ b/docs-ref-services/preview/server-management.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Server Management modules for JavaScript
 description: Reference for Azure Server Management modules for JavaScript
-author: rloutlaw
-ms.author: ROutlaw
+author: ramya-rao-a
+ms.author: ramyar
 manager: angrobe
 ms.date: 07/18/2017
 ms.topic: reference

--- a/docs-ref-services/preview/service-bus-readme.md
+++ b/docs-ref-services/preview/service-bus-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Service Bus client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/service-bus, servicebus
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/05/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/storage-blob-changefeed-readme.md
+++ b/docs-ref-services/preview/storage-blob-changefeed-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage Blob Change Feed client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/storage-blob-changefeed, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/09/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/storage-blob-readme.md
+++ b/docs-ref-services/preview/storage-blob-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage Blob client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/storage-blob, storage
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 07/29/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/storage-file-datalake-readme.md
+++ b/docs-ref-services/preview/storage-file-datalake-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage File Data Lake client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/storage-file-datalake, datalakestorage(gen2)
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 07/29/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/storage-file-share-readme.md
+++ b/docs-ref-services/preview/storage-file-share-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage File Share client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/storage-file-share, storage
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 07/29/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/storage-fileshare-readme.md
+++ b/docs-ref-services/preview/storage-fileshare-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Files for JavaScript Readme
 description: Reference for Azure Storage modules for JavaScript
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 manager: twolley
 ms.date: 03/12/2020
 ms.topic: reference

--- a/docs-ref-services/preview/storage-overview.md
+++ b/docs-ref-services/preview/storage-overview.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage SDK for JavaScript
 description: Reference for Azure Storage SDK for JavaScript
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 manager: twolley
 ms.date: 02/27/2020
 ms.topic: reference

--- a/docs-ref-services/preview/storage-queue-readme.md
+++ b/docs-ref-services/preview/storage-queue-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage Queue client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/storage-queue, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 12/10/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/storage/storage-blob-changefeed-readme.md
+++ b/docs-ref-services/preview/storage/storage-blob-changefeed-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage Blob Change Feed client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/storage-blob-changefeed, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/09/2020
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/storage/storage-overview.md
+++ b/docs-ref-services/preview/storage/storage-overview.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Storage SDK for JavaScript
 description: Reference for Azure Storage SDK for JavaScript
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 manager: twolley
 ms.date: 02/27/2020
 ms.topic: reference

--- a/docs-ref-services/preview/synapse-access-control-readme.md
+++ b/docs-ref-services/preview/synapse-access-control-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Synapse Access Control client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/synapse-access-control, synapseanalytics
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/11/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/synapse-artifacts-readme.md
+++ b/docs-ref-services/preview/synapse-artifacts-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Synapse Artifacts client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/synapse-artifacts, synapseanalytics
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/05/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/synapse-managed-private-endpoints-readme.md
+++ b/docs-ref-services/preview/synapse-managed-private-endpoints-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Synapse Managed Private Endpoints client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/synapse-managed-private-endpoints, synapseanalytics
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 09/08/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/synapse-monitoring-readme.md
+++ b/docs-ref-services/preview/synapse-monitoring-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Synapse Monitoring client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/synapse-monitoring, 
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 02/09/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/synapse-spark-readme.md
+++ b/docs-ref-services/preview/synapse-spark-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Synapse Spark client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/synapse-spark, synapseanalytics
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/05/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/template-readme.md
+++ b/docs-ref-services/preview/template-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Template client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/template, template
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/26/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/video-analyzer-edge-readme.md
+++ b/docs-ref-services/preview/video-analyzer-edge-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Video Analyzer Edge client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/video-analyzer-edge, videoanalyzer
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 10/30/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/web-pubsub-express-readme.md
+++ b/docs-ref-services/preview/web-pubsub-express-readme.md
@@ -1,8 +1,8 @@
 ---
 title: 
 keywords: Azure, javascript, SDK, API, @azure/web-pubsub-express, webpubsub
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 08/02/2021
 ms.topic: reference
 ms.prod: azure

--- a/docs-ref-services/preview/web-pubsub-readme.md
+++ b/docs-ref-services/preview/web-pubsub-readme.md
@@ -1,8 +1,8 @@
 ---
 title: Azure Web PubSub service client library for JavaScript
 keywords: Azure, javascript, SDK, API, @azure/web-pubsub, webpubsub
-author: maggiepint
-ms.author: magpint
+author: ramya-rao-a
+ms.author: ramyar
 ms.date: 07/07/2021
 ms.topic: reference
 ms.prod: azure


### PR DESCRIPTION
**Motivation:**
We currently hard-coded `maggiepint`, `rloutlaw` into our docs metadata. The author metadata is used by Docs.Ms customer to reach out the docs content author. Maggie, and Robert are not here to serve Azure SDK anymore. The contact information has to be updated. 
**Short term approach**
We currently do a mass update for docs repo to update `Maggie` and `Robert` to team docs owner @ramya-rao-a. 

**Long term goal:**
We will have the release pipeline to pick up the CODEOWNERS from lang repo and update the metadata `author` and `msauthor` for package level readme.

For service level readme, we have to work on the automation first and we will work on a concrete plan since then.