### PR TITLE
Update BlobServiceClient.yml

### DIFF
--- a/docs-ref-autogen/@azure/storage-blob/BlobServiceClient.yml
+++ b/docs-ref-autogen/@azure/storage-blob/BlobServiceClient.yml
@@ -384,7 +384,7 @@ methods:
     package: '@azure/storage-blob'
     summary: >-
       Only available for BlobServiceClient constructed with a shared key
-      credential.
+      credential or connection string.
 
       Generates a Blob account Shared Access Signature (SAS) URI based on the
       client properties


### PR DESCRIPTION
As per documentation, generateAccountSasUrl is only available for object constructed with SharedKey credential.
However, we are able to generate SAS with object created using connection string as well.

Repro:
Using below code, created a SAS token

```
import { AccountSASPermissions, AccountSASResourceTypes, BlobServiceClient } from "@azure/storage-blob"
const connStr = "";
const blobServiceClient = BlobServiceClient.fromConnectionString(connStr);
var token = blobServiceClient.generateAccountSasUrl(new Date(new Date().valueOf() + 166400),
AccountSASPermissions.parse("racwdl"),
AccountSASResourceTypes.service);
console.log(token);
```

using the generated token, was able to sucessfully connect to storage using Azure Storage Explorer and also perfomed read, delete and create operations as per the permissions supplied.
![image](https://user-images.githubusercontent.com/72929864/150793352-fc3ed051-8906-491b-8b40-8035fca0d650.png)
