### PR TITLE
Update .openpublishing.publish.config.json

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -65,7 +65,7 @@
     {
       "path_to_root": "azure-sdk-for-js",
       "url": "https://github.com/Azure/azure-sdk-for-js",
-      "branch": "master",
+      "branch": "main",
       "branch_mapping": {}
     }
   ],


### PR DESCRIPTION
dependency repo has been renamed to 'main'