### PR TITLE
Metadata retagging - User story 774326

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -462,7 +462,7 @@
         "docs-ref-autogen/@azure/arm-advisor/**": "advisor",
         "docs-ref-autogen/@azure/arm-analysisservices/**": "analysis-services",
         "docs-ref-autogen/@azure/arm-apimanagement/**": "api-management",
-        "docs-ref-autogen/@azure/arm-appinsights/**": "application-insights",
+        "docs-ref-autogen/@azure/arm-appinsights/**": "azure-monitor",
         "docs-ref-autogen/@azure/arm-authorization/**": "authorization",
         "docs-ref-autogen/@azure/arm-automation/**": "automation",
         "docs-ref-autogen/@azure/arm-azurestack/**": "azure-stack",
@@ -470,7 +470,7 @@
         "docs-ref-autogen/@azure/arm-batch/**": "batch",
         "docs-ref-autogen/@azure/arm-batchai/**": "batch-ai",
         "docs-ref-autogen/@azure/arm-billing/**": "cost-management-billing",
-        "docs-ref-autogen/@azure/arm-cdn/**": "cdn",
+        "docs-ref-autogen/@azure/arm-cdn/**": "azure-cdn",
         "docs-ref-autogen/@azure/arm-cognitiveservices/**": "cognitive-services",
         "docs-ref-autogen/@azure/arm-commerce/**": "commerce",
         "docs-ref-autogen/@azure/arm-compute/**": "virtual-machines",
@@ -502,7 +502,7 @@
         "docs-ref-autogen/@azure/arm-labservices/**": "lab-services",
         "docs-ref-autogen/@azure/arm-links/**": "azure",
         "docs-ref-autogen/@azure/arm-locks/**": "azure",
-        "docs-ref-autogen/@azure/arm-logic/**": "app-service-logic",
+        "docs-ref-autogen/@azure/arm-logic/**": "logic-apps",
         "docs-ref-autogen/@azure/arm-machinelearningcompute/**": "machine-learning",
         "docs-ref-autogen/@azure/arm-machinelearningexperimentation/**": "machine-learning",
         "docs-ref-autogen/@azure/arm-machinelearningservices/**": "machine-learning",
@@ -535,7 +535,7 @@
         "docs-ref-autogen/@azure/arm-reservations/**": "azure",
         "docs-ref-autogen/@azure/arm-resourcehealth/**": "azure-resource-manager",
         "docs-ref-autogen/@azure/arm-resources/**": "azure-resource-manager",
-        "docs-ref-autogen/@azure/arm-search/**": "search",
+        "docs-ref-autogen/@azure/arm-search/**": "cognitive-search",
         "docs-ref-autogen/@azure/arm-security/**": "security",
         "docs-ref-autogen/@azure/arm-servicebus/**": "service-bus",
         "docs-ref-autogen/@azure/arm-servicefabricmesh/**": "service-fabric",
@@ -568,7 +568,7 @@
         "docs-ref-autogen/@azure/identity/**": "azure",
         "docs-ref-autogen/@azure/keyvault-keys/**": "key-vault",
         "docs-ref-autogen/@azure/keyvault-secrets/**": "key-vault",
-        "docs-ref-autogen/@azure/loganalytics/**": "log-analytics",
+        "docs-ref-autogen/@azure/loganalytics/**": "azure-monitor",
         "docs-ref-autogen/@azure/ms-rest-azure-env/**": "azure",
         "docs-ref-autogen/@azure/ms-rest-browserauth/**": "azure",
         "docs-ref-autogen/@azure/ms-rest-js/**": "azure",
@@ -2253,6 +2253,10 @@
         "docs-ref-autogen/@azure/arm-machinelearningexperimentation/**": [
           "https://authoring-docs-microsoft.poolparty.biz/devrel/d6f38669-3d05-40f2-afd8-e49f7dd20884"
         ]
+      },
+      "ms.subservice": {
+        "docs-ref-autogen/@azure/loganalytics/**": "logs",
+        "docs-ref-autogen/@azure/arm-appinsights/**": "application-insights"
       },
       "searchScope": {
         "docs-ref-autogen/@azure/arm-iot*/*.yml": [


### PR DESCRIPTION
Metadata cleanup for the following ms.service values:
- cdn replaced with azure-cdn
- app-service-logic replaced with logic-apps
- log-analytics replaced with azure-monitor and ms.subservice = logs
- search replaced with cognitive-search
- application-insights replaced with azure-monitor and ms-subservice = application-insights

visual-studio-online was not retagged.

For details about this work, see [User story 774326](https://ceapex.visualstudio.com/CPS/_workitems/edit/774326)