### PR TITLE
Disable edit button on learn.microsoft.com for Node

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -22,7 +22,7 @@
         "az-js-servicebus-mgmt-latest",
         "az-js-storage-mgmt-latest"
       ],
-      "open_to_public_contributors": true,
+      "open_to_public_contributors": false,
       "type_mapping": {
         "Conceptual": "Content",
         "ManagedReference": "Content",


### PR DESCRIPTION
open_to_public_contributors was set to true which allows edits, set to false to disable.

Fixes: https://github.com/Azure/azure-sdk-for-js/issues/25412