### PR TITLE
Update PageBlobCreateIfNotExistsResponse.yml

### DIFF
--- a/docs-ref-autogen/@azure/storage-blob/PageBlobCreateIfNotExistsResponse.yml
+++ b/docs-ref-autogen/@azure/storage-blob/PageBlobCreateIfNotExistsResponse.yml
@@ -45,16 +45,16 @@ inheritedProperties:
     uid: '@azure/storage-blob.PageBlobCreateIfNotExistsResponse.contentMD5'
     package: '@azure/storage-blob'
     summary: >-
-      If the blob has an MD5 hash and this operation is to read the full blob,
-      this response header is returned so that the client can check for message
-      content integrity.
+      Represents the numeric values of the MD5 hash hex string. If the blob has
+      an MD5 hash and the originating operation read the full blob, this response
+      header is returned so the client can check for message content integrity.
     fullName: contentMD5
-    remarks: ''
+    remarks: 'The bytes are equivalent to the [<code>Convert.FromHexString</code>](/dotnet/api/system.convert.fromhexstring) output.'
     isDeprecated: false
     syntax:
       content: 'contentMD5?: Uint8Array'
       return:
-        description: ''
+        description: '16-byte long array of MD5 hash hex string.'
         type: Uint8Array
     inheritanceDescription: <b>Inherited From</b> PageBlobCreateResponse.contentMD5
   - name: date


### PR DESCRIPTION
Provide additional detail on the MD5 hash byte array. It is difficult to know how to interpret the byte array without this additional specification. A user might try interpretting the bytes as character encoding or base-64 string text, which would fail.