### PR TITLE
[VirtualMachine] Emphasizing Continued Charges for Stopped Virtual Machines in Azure

### DIFF
--- a/docs-ref-autogen/@azure/arm-compute-profile-2020-09-01-hybrid/VirtualMachines.yml
+++ b/docs-ref-autogen/@azure/arm-compute-profile-2020-09-01-hybrid/VirtualMachines.yml
@@ -509,8 +509,8 @@ methods:
       The operation to power off (stop) a virtual machine. The virtual machine
       can be restarted with the
 
-      same provisioned resources. You are still charged for this virtual
-      machine.
+      same provisioned resources. **You are still charged for this virtual
+      machine.**
     remarks: ''
     isDeprecated: false
     syntax:
@@ -544,8 +544,8 @@ methods:
       The operation to power off (stop) a virtual machine. The virtual machine
       can be restarted with the
 
-      same provisioned resources. You are still charged for this virtual
-      machine.
+      same provisioned resources. **You are still charged for this virtual
+      machine.**
     remarks: ''
     isDeprecated: false
     syntax:

--- a/docs-ref-autogen/@azure/arm-compute/VirtualMachines.yml
+++ b/docs-ref-autogen/@azure/arm-compute/VirtualMachines.yml
@@ -636,8 +636,8 @@ methods:
       The operation to power off (stop) a virtual machine. The virtual machine
       can be restarted with the
 
-      same provisioned resources. You are still charged for this virtual
-      machine.
+      same provisioned resources. **You are still charged for this virtual
+      machine.**
     remarks: ''
     isDeprecated: false
     syntax:
@@ -671,8 +671,8 @@ methods:
       The operation to power off (stop) a virtual machine. The virtual machine
       can be restarted with the
 
-      same provisioned resources. You are still charged for this virtual
-      machine.
+      same provisioned resources. **You are still charged for this virtual
+      machine.**
     remarks: ''
     isDeprecated: false
     syntax:


### PR DESCRIPTION
Changes:

> The operation to power off (stop) a virtual machine. The virtual machine can be restarted with the same provisioned resources. **You are still charged for this virtual machine.**