### PR TITLE
Add docsms-allowlist directory to allow list for the repository

### DIFF
--- a/docsms-allowlist/js-allowlist.txt
+++ b/docsms-allowlist/js-allowlist.txt
@@ -7,4 +7,5 @@
 ^preview-packages/docs-ref-mapping/
 ^previous-packages/docs-ref-autogen/
 ^previous-packages/docs-ref-mapping/
+^docsms-allowlist/
 docfx.json


### PR DESCRIPTION
My preview PR updated the allow list and that change failed the auto-merge. The allow list isn't a file that's often updated and, even then, is only updated by hand, not automation. Don't prevent the auto-merge from main->live for allow list changes.