### PR TITLE
Remove -index.md files from publishing (reduces OPS publishing errors)

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -280,6 +280,7 @@
           "**/*.md",
           "**/*.yml"
         ],
+        "exclude": [ "**/*-index.md"],
         "src": "docs-ref-services/latest",
         "dest": "api/overview/azure",
         "group": "stable",
@@ -290,6 +291,7 @@
           "**/*.md",
           "**/*.yml"
         ],
+        "exclude": [ "**/*-index.md"],
         "src": "docs-ref-services/preview",
         "dest": "api/overview/azure",
         "group": "preview",
@@ -300,6 +302,7 @@
           "**/*.md",
           "**/*.yml"
         ],
+        "exclude": [ "**/*-index.md"],
         "src": "docs-ref-services/legacy",
         "dest": "api/overview/azure",
         "group": "legacy",


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-js/issues/26493