### PR TITLE
Remove deprecated ms.prod and ms.technology metadata

### DIFF
--- a/docs-ref-services/latest/ai-metrics-advisor-readme.md
+++ b/docs-ref-services/latest/ai-metrics-advisor-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: javascript
 ms.service: cognitive-services
 ms.subservice: metrics-advisor
-ms.technology: azure
 ---
 # Azure Metrics Advisor client library for JavaScript - version 1.0.0 
 

--- a/docs-ref-services/latest/ai-text-analytics-readme.md
+++ b/docs-ref-services/latest/ai-text-analytics-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: javascript
 ms.service: cognitive-services
 ms.subservice: text-analytics
-ms.technology: azure
 ---
 # Azure Text Analytics client library for JavaScript - version 5.1.0 
 

--- a/docs-ref-services/latest/arm-containerregistry-readme.md
+++ b/docs-ref-services/latest/arm-containerregistry-readme.md
@@ -5,7 +5,6 @@ ms.date: 03/22/2023
 ms.topic: reference
 ms.devlang: javascript
 ms.service: container-registry
-ms.technology: azure
 ---
 # Azure ContainerRegistryManagement client library for JavaScript - version 10.1.0 
 

--- a/docs-ref-services/latest/arm-hardwaresecuritymodules-readme.md
+++ b/docs-ref-services/latest/arm-hardwaresecuritymodules-readme.md
@@ -5,7 +5,6 @@ ms.date: 04/01/2022
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure
-ms.technology: azure
 ---
 # Azure Service client library for JavaScript - version 1.0.0 
 

--- a/docs-ref-services/latest/arm-hybridcompute-readme.md
+++ b/docs-ref-services/latest/arm-hybridcompute-readme.md
@@ -5,7 +5,6 @@ ms.date: 01/19/2022
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure
-ms.technology: azure
 ---
 # Azure HybridComputeManagement client library for JavaScript - version 3.0.0 
 

--- a/docs-ref-services/latest/arm-iotcentral-readme.md
+++ b/docs-ref-services/latest/arm-iotcentral-readme.md
@@ -5,7 +5,6 @@ ms.date: 01/20/2022
 ms.topic: reference
 ms.devlang: javascript
 ms.service: iot-central
-ms.technology: azure
 ---
 # Azure IotCentral client library for JavaScript - version 6.0.0 
 

--- a/docs-ref-services/latest/arm-links-readme.md
+++ b/docs-ref-services/latest/arm-links-readme.md
@@ -5,7 +5,6 @@ ms.date: 04/20/2022
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure
-ms.technology: azure
 ---
 # Azure ManagementLink client library for JavaScript - version 2.0.1 
 

--- a/docs-ref-services/latest/arm-machinelearningservices-readme.md
+++ b/docs-ref-services/latest/arm-machinelearningservices-readme.md
@@ -5,7 +5,6 @@ ms.date: 04/28/2022
 ms.topic: reference
 ms.devlang: javascript
 ms.service: machine-learning
-ms.technology: azure
 ---
 # Azure Service client library for JavaScript - version 5.0.1 
 

--- a/docs-ref-services/latest/arm-mixedreality-readme.md
+++ b/docs-ref-services/latest/arm-mixedreality-readme.md
@@ -5,7 +5,6 @@ ms.date: 01/20/2022
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure
-ms.technology: azure
 ---
 # Azure MixedReality client library for JavaScript - version 4.0.1 
 

--- a/docs-ref-services/latest/arm-monitor-readme.md
+++ b/docs-ref-services/latest/arm-monitor-readme.md
@@ -5,7 +5,6 @@ ms.date: 12/21/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure-monitor
-ms.technology: azure
 ---
 # Azure Monitor client library for JavaScript - version 7.0.0 
 

--- a/docs-ref-services/latest/arm-policyinsights-readme.md
+++ b/docs-ref-services/latest/arm-policyinsights-readme.md
@@ -5,7 +5,6 @@ ms.date: 01/24/2022
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure-policy
-ms.technology: azure
 ---
 # Azure PolicyInsights client library for JavaScript - version 5.0.0 
 

--- a/docs-ref-services/latest/arm-security-readme.md
+++ b/docs-ref-services/latest/arm-security-readme.md
@@ -5,7 +5,6 @@ ms.date: 04/01/2022
 ms.topic: reference
 ms.devlang: javascript
 ms.service: security-center
-ms.technology: azure
 ---
 # Azure Service client library for JavaScript - version 5.0.0 
 

--- a/docs-ref-services/latest/arm-synapse-readme.md
+++ b/docs-ref-services/latest/arm-synapse-readme.md
@@ -5,7 +5,6 @@ ms.date: 01/14/2022
 ms.topic: reference
 ms.devlang: javascript
 ms.service: synapse-analytics
-ms.technology: azure
 ---
 # Azure SynapseManagement client library for JavaScript - version 8.0.0 
 

--- a/docs-ref-services/latest/arm-timeseriesinsights-readme.md
+++ b/docs-ref-services/latest/arm-timeseriesinsights-readme.md
@@ -5,7 +5,6 @@ ms.date: 01/21/2022
 ms.topic: reference
 ms.devlang: javascript
 ms.service: time-series-insights
-ms.technology: azure
 ---
 # Azure TimeSeriesInsights client library for JavaScript - version 2.0.0 
 

--- a/docs-ref-services/latest/arm-webpubsub-readme.md
+++ b/docs-ref-services/latest/arm-webpubsub-readme.md
@@ -5,7 +5,6 @@ ms.date: 03/20/2023
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure-web-pubsub
-ms.technology: azure
 ---
 # Azure WebPubSubManagement client library for JavaScript - version 1.1.0 
 

--- a/docs-ref-services/latest/attestation-readme.md
+++ b/docs-ref-services/latest/attestation-readme.md
@@ -5,7 +5,6 @@ ms.date: 08/13/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: attestation
-ms.technology: azure
 ---
 # Azure Attestation client library for JavaScript - version 1.0.0 
 

--- a/docs-ref-services/latest/billing.md
+++ b/docs-ref-services/latest/billing.md
@@ -6,8 +6,6 @@ ms.topic: reference
 ms.devlang: javascript
 ms.service: billing
 manager: timlt
-ms.product: 
-ms.technology: 
 ---
 # Azure Billing modules for JavaScript
 

--- a/docs-ref-services/latest/cdn.md
+++ b/docs-ref-services/latest/cdn.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: azure-cdn
 manager: v-laurab
-ms.technology: azure
 ---
 # Azure CDN modules for JavaScript
 

--- a/docs-ref-services/latest/cognitiveservices-autosuggest-readme.md
+++ b/docs-ref-services/latest/cognitiveservices-autosuggest-readme.md
@@ -5,7 +5,6 @@ ms.topic: reference
 ms.devlang: javascript
 ms.service: cognitive-services
 ms.subservice: bing-autosuggest
-ms.technology: azure
 ---
 # Bing Autosuggest
 

--- a/docs-ref-services/latest/cognitiveservices-customimagesearch-readme.md
+++ b/docs-ref-services/latest/cognitiveservices-customimagesearch-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Custom Image Search
 

--- a/docs-ref-services/latest/cognitiveservices-customsearch-readme.md
+++ b/docs-ref-services/latest/cognitiveservices-customsearch-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Custom Search
 

--- a/docs-ref-services/latest/cognitiveservices-entitysearch-readme.md
+++ b/docs-ref-services/latest/cognitiveservices-entitysearch-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Entity Search
 

--- a/docs-ref-services/latest/cognitiveservices-face-readme.md
+++ b/docs-ref-services/latest/cognitiveservices-face-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: javascript
 ms.service: cognitive-services
 ms.subservice: face-api
-ms.technology: 
 ---
 # Azure Face API
 

--- a/docs-ref-services/latest/cognitiveservices-imagesearch-readme.md
+++ b/docs-ref-services/latest/cognitiveservices-imagesearch-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Image Search
 

--- a/docs-ref-services/latest/cognitiveservices-newssearch-readme.md
+++ b/docs-ref-services/latest/cognitiveservices-newssearch-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing News Search
 

--- a/docs-ref-services/latest/cognitiveservices-spellcheck-readme.md
+++ b/docs-ref-services/latest/cognitiveservices-spellcheck-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Spell Check
 

--- a/docs-ref-services/latest/cognitiveservices-videosearch-readme.md
+++ b/docs-ref-services/latest/cognitiveservices-videosearch-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Video Search
 

--- a/docs-ref-services/latest/cognitiveservices-visualsearch-readme.md
+++ b/docs-ref-services/latest/cognitiveservices-visualsearch-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Visual Search
 

--- a/docs-ref-services/latest/cognitiveservices-websearch-readme.md
+++ b/docs-ref-services/latest/cognitiveservices-websearch-readme.md
@@ -5,7 +5,6 @@ ms.topic: reference
 ms.devlang: javascript
 ms.service: cognitive-services
 ms.subservice: bing-web-search
-ms.technology: azure
 ---
 # Bing Web Search API
 

--- a/docs-ref-services/latest/communication-network-traversal-readme.md
+++ b/docs-ref-services/latest/communication-network-traversal-readme.md
@@ -5,7 +5,6 @@ ms.date: 02/04/2022
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure-communication-services
-ms.technology: azure
 ---
 # Azure Communication Network Traversal client library for JavaScript - version 1.0.0 
 

--- a/docs-ref-services/latest/communication-phone-numbers-readme.md
+++ b/docs-ref-services/latest/communication-phone-numbers-readme.md
@@ -5,7 +5,6 @@ ms.date: 03/29/2023
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure-communication-services
-ms.technology: azure
 ---
 # Azure Communication Phone Numbers client library for JavaScript - version 1.2.0 
 

--- a/docs-ref-services/latest/core-asynciterator-polyfill-readme.md
+++ b/docs-ref-services/latest/core-asynciterator-polyfill-readme.md
@@ -5,7 +5,6 @@ ms.date: 02/09/2022
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure
-ms.technology: azure
 ---
 # Azure Async Iterator Polyfill client library for JavaScript - version 1.0.2 
 

--- a/docs-ref-services/latest/datalake-store.md
+++ b/docs-ref-services/latest/datalake-store.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: data-lake-store
 manager: routlaw
-ms.technology: azure
 ---
 # Azure Data Lake Store modules for Node.JS
 

--- a/docs-ref-services/latest/identity-cache-persistence-readme.md
+++ b/docs-ref-services/latest/identity-cache-persistence-readme.md
@@ -5,7 +5,6 @@ ms.date: 10/16/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: identity
-ms.technology: azure
 ---
 ## Azure Identity Plugin for Token Cache Persistence
 

--- a/docs-ref-services/latest/identity-vscode-readme.md
+++ b/docs-ref-services/latest/identity-vscode-readme.md
@@ -5,7 +5,6 @@ ms.date: 10/16/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: identity
-ms.technology: azure
 ---
 ## Azure Identity Plugin for Visual Studio Code Authentication
 

--- a/docs-ref-services/latest/key-vault/key-vault-index.md
+++ b/docs-ref-services/latest/key-vault/key-vault-index.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: key-vault
 manager: mbaldwin
-ms.technology: azure
 ---
 ## Azure Key Vault SDK for JavaScript - latest
 

--- a/docs-ref-services/latest/key-vault/keyvault-certificates-readme.md
+++ b/docs-ref-services/latest/key-vault/keyvault-certificates-readme.md
@@ -5,7 +5,6 @@ ms.date: 07/29/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: key-vault
-ms.technology: azure
 ---
 # Azure Key Vault Certificates client library for JavaScript - version 4.3.0 
 

--- a/docs-ref-services/latest/key-vault/keyvault-keys-readme.md
+++ b/docs-ref-services/latest/key-vault/keyvault-keys-readme.md
@@ -5,7 +5,6 @@ ms.date: 07/29/2021
 ms.topic: article
 ms.devlang: javascript
 ms.service: key-vault
-ms.technology: azure
 ---
 # Azure Key Vault Key client library for JavaScript - version 4.3.0 
 

--- a/docs-ref-services/latest/key-vault/keyvault-secrets-readme.md
+++ b/docs-ref-services/latest/key-vault/keyvault-secrets-readme.md
@@ -5,7 +5,6 @@ ms.date: 07/29/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: key-vault
-ms.technology: azure
 ---
 # Azure Key Vault Secret client library for JavaScript - version 4.3.0 
 

--- a/docs-ref-services/latest/power-bi.md
+++ b/docs-ref-services/latest/power-bi.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: power-bi-embedded
 manager: kfile
-ms.technology: azure
 ---
 # Azure PowerBI Embedded modules for JavaScript
 

--- a/docs-ref-services/latest/scheduler.md
+++ b/docs-ref-services/latest/scheduler.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: scheduler
 manager: angrobe
-ms.technology: azure
 ---
 # Azure Scheduler modules for JavaScript
 

--- a/docs-ref-services/latest/server-management.md
+++ b/docs-ref-services/latest/server-management.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: azure-asm
 manager: angrobe
-ms.technology: azure
 ---
 # Azure Server Management modules for JavaScript
 

--- a/docs-ref-services/latest/service-bus-readme-legacy.md
+++ b/docs-ref-services/latest/service-bus-readme-legacy.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: service-bus
 manager: timlt
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Node.js - azure-sb - Version 0.11.1
 

--- a/docs-ref-services/latest/site-recovery.md
+++ b/docs-ref-services/latest/site-recovery.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: javascript
 ms.service: siterecovery
 manager: carmonm
-ms.technology: azure
 ---
 # Azure Site Recovery modules for JavaScript
 

--- a/docs-ref-services/latest/storage-fileshare-readme.md
+++ b/docs-ref-services/latest/storage-fileshare-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: javascript
 ms.service: storage
 ms.subservice: files
-ms.technology: azure
 manager: twolley
 ---
 # Azure Files for JavaScript Readme - Version 12.1.1

--- a/docs-ref-services/latest/storage/storage-blob-readme.md
+++ b/docs-ref-services/latest/storage/storage-blob-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/10/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: storage
-ms.technology: azure
 ---
 # Azure Storage Blob client library for JavaScript - version 12.8.0 
 

--- a/docs-ref-services/latest/storage/storage-file-datalake-readme.md
+++ b/docs-ref-services/latest/storage/storage-file-datalake-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/10/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: data-lake-storage-gen2
-ms.technology: azure
 ---
 # Azure Storage File Data Lake client library for JavaScript - version 12.7.0 
 

--- a/docs-ref-services/latest/storage/storage-file-share-readme.md
+++ b/docs-ref-services/latest/storage/storage-file-share-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/10/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: storage
-ms.technology: azure
 ---
 # Azure Storage File Share client library for JavaScript - version 12.8.0 
 

--- a/docs-ref-services/latest/storage/storage-fileshare-readme.md
+++ b/docs-ref-services/latest/storage/storage-fileshare-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: javascript
 ms.service: storage
 manager: twolley
-ms.technology: azure
 ---
 # Azure Files for JavaScript Readme - Version 12.1.1
 

--- a/docs-ref-services/latest/storage/storage-mgmt-overview.md
+++ b/docs-ref-services/latest/storage/storage-mgmt-overview.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: JavaScript
 ms.service: storage
 manager: twolley
-ms.technology: azure
 ---
 ## Management - Latest
 

--- a/docs-ref-services/latest/storage/storage-overview.md
+++ b/docs-ref-services/latest/storage/storage-overview.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: JavaScript
 ms.service: storage
 manager: twolley
-ms.technology: azure
 ---
 # Azure Storage SDK for JavaScript - latest
 

--- a/docs-ref-services/latest/storage/storage-queue-readme.md
+++ b/docs-ref-services/latest/storage/storage-queue-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/10/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: storage
-ms.technology: azure
 ---
 # Azure Storage Queue client library for JavaScript - version 12.7.0 
 

--- a/docs-ref-services/latest/template-readme.md
+++ b/docs-ref-services/latest/template-readme.md
@@ -5,7 +5,6 @@ ms.date: 06/15/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure
-ms.technology: azure
 ---
 # Azure Template client library for JavaScript - version 1.0.12 
 

--- a/docs-ref-services/latest/virtual-machines.md
+++ b/docs-ref-services/latest/virtual-machines.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: big-compute
 manager: jeconnoc
-ms.technology: azure
 ---
 # Azure Virtual Machine Modules for JavaScript
 

--- a/docs-ref-services/latest/virtual-network.md
+++ b/docs-ref-services/latest/virtual-network.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: virtual-network
 manager: jeconnoc
-ms.technology: azure
 ---
 # Azure Virtual Network modules for JavaScript
 

--- a/docs-ref-services/legacy/ai-anomaly-detector-readme.md
+++ b/docs-ref-services/legacy/ai-anomaly-detector-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: javascript
 ms.service: cognitive-services
 ms.subservice: anomaly-detector
-ms.technology: azure
 ---
 # Azure Anomaly Detector client library for JavaScript - version 3.0.0-beta.5 
 

--- a/docs-ref-services/legacy/ai-form-recognizer-readme.md
+++ b/docs-ref-services/legacy/ai-form-recognizer-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: javascript
 ms.service: applied-ai-services
 ms.subservice: forms-recognizer
-ms.technology: azure
 ---
 # Azure Form Recognizer client library for JavaScript - version 3.0.0 
 

--- a/docs-ref-services/legacy/ai-text-analytics-readme.md
+++ b/docs-ref-services/legacy/ai-text-analytics-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: javascript
 ms.service: cognitive-services
 ms.subservice: text-analytics
-ms.technology: azure
 ---
 # Azure Text Analytics client library for JavaScript - version 5.0.1 
 

--- a/docs-ref-services/legacy/analysis-services.md
+++ b/docs-ref-services/legacy/analysis-services.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: azure-analysis-services
 manager: kfile
-ms.technology: azure
 ---
 # Azure Analysis Services modules for JavaScript
 

--- a/docs-ref-services/legacy/app-service.md
+++ b/docs-ref-services/legacy/app-service.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: app-service
 manager: jhubbard
-ms.technology: azure
 ---
 # Azure App Service modules for JavaScript
 

--- a/docs-ref-services/legacy/authorization.md
+++ b/docs-ref-services/legacy/authorization.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: app-service
 manager: angrobe
-ms.technology: azure
 ---
 # Azure Authorization modules for JavaScript
 

--- a/docs-ref-services/legacy/batch-ai.md
+++ b/docs-ref-services/legacy/batch-ai.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: batch-ai
 manager: cjgronlund
-ms.technology: azure
 ---
 # Batch AI Modules for JavaScript
 

--- a/docs-ref-services/legacy/billing.md
+++ b/docs-ref-services/legacy/billing.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: billing
 manager: timlt
-ms.technology: 
 ms.product: 
 ---
 # Azure Billing modules for JavaScript

--- a/docs-ref-services/legacy/cdn.md
+++ b/docs-ref-services/legacy/cdn.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: azure-cdn
 manager: v-laurab
-ms.technology: azure
 ---
 # Azure CDN modules for JavaScript
 

--- a/docs-ref-services/legacy/cognitiveservices-autosuggest-readme.md
+++ b/docs-ref-services/legacy/cognitiveservices-autosuggest-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Autosuggest
 

--- a/docs-ref-services/legacy/cognitiveservices-customimagesearch-readme.md
+++ b/docs-ref-services/legacy/cognitiveservices-customimagesearch-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Custom Image Search
 

--- a/docs-ref-services/legacy/cognitiveservices-customsearch-readme.md
+++ b/docs-ref-services/legacy/cognitiveservices-customsearch-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Custom Search
 

--- a/docs-ref-services/legacy/cognitiveservices-entitysearch-readme.md
+++ b/docs-ref-services/legacy/cognitiveservices-entitysearch-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Entity Search
 

--- a/docs-ref-services/legacy/cognitiveservices-imagesearch-readme.md
+++ b/docs-ref-services/legacy/cognitiveservices-imagesearch-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Image Search
 

--- a/docs-ref-services/legacy/cognitiveservices-newssearch-readme.md
+++ b/docs-ref-services/legacy/cognitiveservices-newssearch-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing News Search
 

--- a/docs-ref-services/legacy/cognitiveservices-spellcheck-readme.md
+++ b/docs-ref-services/legacy/cognitiveservices-spellcheck-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Spell Check
 

--- a/docs-ref-services/legacy/cognitiveservices-videosearch-readme.md
+++ b/docs-ref-services/legacy/cognitiveservices-videosearch-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Video Search
 

--- a/docs-ref-services/legacy/cognitiveservices-visualsearch-readme.md
+++ b/docs-ref-services/legacy/cognitiveservices-visualsearch-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Visual Search
 

--- a/docs-ref-services/legacy/cognitiveservices-websearch-readme.md
+++ b/docs-ref-services/legacy/cognitiveservices-websearch-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Web Search API
 

--- a/docs-ref-services/legacy/commerce.md
+++ b/docs-ref-services/legacy/commerce.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: azure
 manager: angrobew
-ms.technology: azure
 ---
 # Azure Commerce modules for JavaScript
 

--- a/docs-ref-services/legacy/communication-network-traversal-readme.md
+++ b/docs-ref-services/legacy/communication-network-traversal-readme.md
@@ -5,7 +5,6 @@ ms.date: 03/11/2022
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure-communication-services
-ms.technology: azure
 ---
 # Azure Communication Network Traversal client library for JavaScript - version 1.1.0-beta.1 
 

--- a/docs-ref-services/legacy/container-registry.md
+++ b/docs-ref-services/legacy/container-registry.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: container-registry
 manager: jeconnoc
-ms.technology: azure
 ---
 # Azure Container Registry modules for JavaScript
 

--- a/docs-ref-services/legacy/container-service.md
+++ b/docs-ref-services/legacy/container-service.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: container-service
 manager: jeconnoc
-ms.technology: azure
 ---
 # Microsoft Azure SDK for JavaScript - ContainerServiceClient
 This project provides a JavaScript package for accessing Azure. Right now it supports:

--- a/docs-ref-services/legacy/core-amqp-readme.md
+++ b/docs-ref-services/legacy/core-amqp-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/12/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure
-ms.technology: azure
 ---
 # Azure Core AMQP client library for AMQP operations
 

--- a/docs-ref-services/legacy/core-auth-readme.md
+++ b/docs-ref-services/legacy/core-auth-readme.md
@@ -5,7 +5,6 @@ ms.date: 06/30/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure
-ms.technology: azure
 ---
 ## Azure Core Authentication
 

--- a/docs-ref-services/legacy/core-http-readme.md
+++ b/docs-ref-services/legacy/core-http-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/06/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure
-ms.technology: azure
 ---
 # Azure Core HTTP client library for JavaScript - version 1.2.0 
 

--- a/docs-ref-services/legacy/core-paging-readme.md
+++ b/docs-ref-services/legacy/core-paging-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/30/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure
-ms.technology: azure
 ---
 # Azure Core Paging client library for JavaScript - version 1.1.3 
 

--- a/docs-ref-services/legacy/cosmos-readme.md
+++ b/docs-ref-services/legacy/cosmos-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/09/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: cosmos-db
-ms.technology: azure
 ---
 # Azure Cosmos DB client library for JavaScript - version 3.9.3 
 /TypeScript

--- a/docs-ref-services/legacy/data-lake-analytics.md
+++ b/docs-ref-services/legacy/data-lake-analytics.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: data-lake-analytics
 manager: routlaw
-ms.technology: azure
 ---
 # Azure Data Lake Analytics modules for Node.JS
 

--- a/docs-ref-services/legacy/datalake-store.md
+++ b/docs-ref-services/legacy/datalake-store.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: data-lake-store
 manager: routlaw
-ms.technology: azure
 ---
 # Azure Data Lake Store modules for Node.JS
 

--- a/docs-ref-services/legacy/devtest-labs.md
+++ b/docs-ref-services/legacy/devtest-labs.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: devtest-lab
 manager: v-laurab
-ms.technology: azure
 ---
 # Azure DevTest Labs modules for JavaScript
 

--- a/docs-ref-services/legacy/digital-twins-core-readme.md
+++ b/docs-ref-services/legacy/digital-twins-core-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/03/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: digital-twins
-ms.technology: azure
 ---
 # Azure Azure Digital Twins Core client library for JavaScript - version 1.0.0 
 

--- a/docs-ref-services/legacy/dns.md
+++ b/docs-ref-services/legacy/dns.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: dns
 manager: jeconnoc
-ms.technology: azure
 ---
 # Azure DNS modules for JavaScript
 

--- a/docs-ref-services/legacy/event-grid.md
+++ b/docs-ref-services/legacy/event-grid.md
@@ -8,7 +8,7 @@ ms.service: azure-event-grid
 manager: angerobe
 ms.prod: 
 ms.custom: devcenter
-ms.technology: 
+manager: angerobe
 ---
 # Azure Event Grid libraries for JavaScript
 

--- a/docs-ref-services/legacy/event-hubs-readme.md
+++ b/docs-ref-services/legacy/event-hubs-readme.md
@@ -5,7 +5,6 @@ ms.date: 02/02/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: event-hubs
-ms.technology: azure
 ---
 # Azure Event Hubs client library for JavaScript - version 2.1.4 
 

--- a/docs-ref-services/legacy/identity-readme.md
+++ b/docs-ref-services/legacy/identity-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/11/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: identity
-ms.technology: azure
 ---
 ## Azure Identity client library for JavaScript - version 1.2.0 
 

--- a/docs-ref-services/legacy/iot-hub.md
+++ b/docs-ref-services/legacy/iot-hub.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: iot-hub
 manager: timlt
-ms.technology: azure
 ---
 # Azure IoT Hub modules for JavaScript
 

--- a/docs-ref-services/legacy/key-vault/key-vault-index.md
+++ b/docs-ref-services/legacy/key-vault/key-vault-index.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: key-vault
 manager: mbaldwin
-ms.technology: azure
 ---
 # Azure Key Vault SDK for JavaScript - legacy
 

--- a/docs-ref-services/legacy/key-vault/keyvault-certificates-readme.md
+++ b/docs-ref-services/legacy/key-vault/keyvault-certificates-readme.md
@@ -5,7 +5,6 @@ ms.date: 08/12/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: key-vault
-ms.technology: azure
 ---
 # Azure Key Vault Certificates client library for JavaScript - version 4.1.0 
 

--- a/docs-ref-services/legacy/key-vault/keyvault-keys-readme.md
+++ b/docs-ref-services/legacy/key-vault/keyvault-keys-readme.md
@@ -5,7 +5,6 @@ ms.date: 08/12/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: key-vault
-ms.technology: azure
 ---
 # Azure Key Vault Key client library for JavaScript - version 4.1.0 
 

--- a/docs-ref-services/legacy/key-vault/keyvault-secrets-readme.md
+++ b/docs-ref-services/legacy/key-vault/keyvault-secrets-readme.md
@@ -5,7 +5,6 @@ ms.date: 08/12/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: key-vault
-ms.technology: azure
 ---
 # Azure Key Vault Secret client library for JavaScript - version 4.1.0 
 

--- a/docs-ref-services/legacy/keyvault-certificates-readme.md
+++ b/docs-ref-services/legacy/keyvault-certificates-readme.md
@@ -5,7 +5,6 @@ ms.date: 08/12/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: key-vault
-ms.technology: azure
 ---
 # Azure Key Vault Certificates client library for JavaScript - version 4.1.0 
 

--- a/docs-ref-services/legacy/keyvault-keys-readme.md
+++ b/docs-ref-services/legacy/keyvault-keys-readme.md
@@ -5,7 +5,6 @@ ms.date: 08/12/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: key-vault
-ms.technology: azure
 ---
 # Azure Key Vault Key client library for JavaScript - version 4.1.0 
 

--- a/docs-ref-services/legacy/keyvault-secrets-readme.md
+++ b/docs-ref-services/legacy/keyvault-secrets-readme.md
@@ -5,7 +5,6 @@ ms.date: 08/12/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: key-vault
-ms.technology: azure
 ---
 # Azure Key Vault Secret client library for JavaScript - version 4.1.0 
 

--- a/docs-ref-services/legacy/logic-apps.md
+++ b/docs-ref-services/legacy/logic-apps.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: logic-apps
 manager: cfowler
-ms.technology: azure
 ---
 # Azure Logic Apps modules for JavaScript
 

--- a/docs-ref-services/legacy/media-services.md
+++ b/docs-ref-services/legacy/media-services.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: media-services
 manager: cfowler
-ms.technology: azure
 ---
 # Azure Media Services modules for JavaScript
 

--- a/docs-ref-services/legacy/mixed-reality.md
+++ b/docs-ref-services/legacy/mixed-reality.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: azure
 manager: dgriff
-ms.technology: azure
 ---
 # Azure Mixed Reality Resource Management Modules for JavaScript
 

--- a/docs-ref-services/legacy/notification-hubs.md
+++ b/docs-ref-services/legacy/notification-hubs.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: notification-hubs
 manager: angrobe
-ms.technology: azure
 ---
 # Azure Notification Hubs modules for JavaScript
 

--- a/docs-ref-services/legacy/operational-insights.md
+++ b/docs-ref-services/legacy/operational-insights.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: operational-insights
 manager: carmonm
-ms.technology: azure
 ---
 # Azure Operational Insights Modules for JavaScript
 

--- a/docs-ref-services/legacy/power-bi.md
+++ b/docs-ref-services/legacy/power-bi.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: power-bi-embedded
 manager: kfile
-ms.technology: azure
 ---
 # Azure PowerBI Embedded modules for JavaScript
 

--- a/docs-ref-services/legacy/purview-account-rest-readme.md
+++ b/docs-ref-services/legacy/purview-account-rest-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/01/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: purview
-ms.technology: azure
 ---
 # Azure Purview Account REST client library for JavaScript - version 1.0.0-beta.1 
 

--- a/docs-ref-services/legacy/redis-cache.md
+++ b/docs-ref-services/legacy/redis-cache.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: cache
 manager: cfowler
-ms.technology: azure
 ---
 # Azure Redis Cache modules for JavaScript
 

--- a/docs-ref-services/legacy/relay.md
+++ b/docs-ref-services/legacy/relay.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: service-bus-relay
 manager: timlt
-ms.technology: azure
 ---
 # Azure Relay modules for JavaScript
 

--- a/docs-ref-services/legacy/resources.md
+++ b/docs-ref-services/legacy/resources.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: azure-resource-manager
 manager: timlt
-ms.technology: azure
 ---
 # Azure Resource modules for JavaScript
 

--- a/docs-ref-services/legacy/scheduler.md
+++ b/docs-ref-services/legacy/scheduler.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: scheduler
 manager: angrobe
-ms.technology: azure
 ---
 # Azure Scheduler modules for JavaScript
 

--- a/docs-ref-services/legacy/search-documents-readme.md
+++ b/docs-ref-services/legacy/search-documents-readme.md
@@ -5,7 +5,6 @@ ms.date: 07/31/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: cognitive-search
-ms.technology: azure
 ---
 # Azure Cognitive Search client library for JavaScript - version 11.0.2 
 

--- a/docs-ref-services/legacy/server-management.md
+++ b/docs-ref-services/legacy/server-management.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: azure-asm
 manager: angrobe
-ms.technology: azure
 ---
 # Azure Server Management modules for JavaScript
 

--- a/docs-ref-services/legacy/service-bus-readme-legacy.md
+++ b/docs-ref-services/legacy/service-bus-readme-legacy.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: service-bus
 manager: timlt
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Node.js - azure-sb - Version 0.11.1
 

--- a/docs-ref-services/legacy/service-bus-readme.md
+++ b/docs-ref-services/legacy/service-bus-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/23/2020
 ms.topic: reference
 ms.devlang: 
 ms.service: service-bus
-ms.technology: azure
 ---
 # Azure Service Bus client library for JavaScript - version 7.0.0 
 

--- a/docs-ref-services/legacy/service-bus.md
+++ b/docs-ref-services/legacy/service-bus.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: service-bus
 manager: timlt
-ms.technology: azure
 ---
 # Azure Service Bus Modules for JavaScript
 

--- a/docs-ref-services/legacy/service-fabric.md
+++ b/docs-ref-services/legacy/service-fabric.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: service-fabric
 manager: timlt
-ms.technology: azure
 ---
 # Azure Service Fabric modules for JavaScript
 

--- a/docs-ref-services/legacy/service-map.md
+++ b/docs-ref-services/legacy/service-map.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: azure-maps
 manager: carmonm
-ms.technology: azure
 ---
 # Azure Service Map modules for JavaScript
 

--- a/docs-ref-services/legacy/site-recovery.md
+++ b/docs-ref-services/legacy/site-recovery.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: site-recovery
 manager: carmonm
-ms.technology: azure
 ---
 # Azure Site Recovery modules for JavaScript
 

--- a/docs-ref-services/legacy/storage-blob-readme.md
+++ b/docs-ref-services/legacy/storage-blob-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: javascript
 ms.service: storage
 ms.subservice: blobs
-ms.technology: azure
 ---
 # Azure Storage SDK V10 for JavaScript - Blob
 

--- a/docs-ref-services/legacy/storage-file-datalake-readme.md
+++ b/docs-ref-services/legacy/storage-file-datalake-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: javascript
 ms.service: storage
 ms.subservice: data-lake-storage-gen2
-ms.technology: azure
 ---
 # Azure Storage File Data Lake client library for JavaScript - version 12.2.0 
 

--- a/docs-ref-services/legacy/storage-file-share-readme.md
+++ b/docs-ref-services/legacy/storage-file-share-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: javascript
 ms.service: storage
 ms.subservice: files
-ms.technology: azure
 ---
 # Azure Storage File Share client library for JavaScript - version 12.3.0 
 

--- a/docs-ref-services/legacy/storage-fileshare-readme.md
+++ b/docs-ref-services/legacy/storage-fileshare-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: javascript
 ms.service: storage
 ms.subservice: files
-ms.technology: azure
 manager: twolley
 ---
 # Azure Files for JavaScript Readme - Version 12.1.1

--- a/docs-ref-services/legacy/storage-queue-readme.md
+++ b/docs-ref-services/legacy/storage-queue-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: javascript
 ms.service: storage
 ms.subservice: queues
-ms.technology: azure
 ---
 # Azure Storage SDK V10 for JavaScript - Queue
 

--- a/docs-ref-services/legacy/storage/storage-blob-readme.md
+++ b/docs-ref-services/legacy/storage/storage-blob-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: javascript
 ms.service: storage
 ms.subservice: blobs
-ms.technology: azure
 ---
 # Azure Storage SDK V10 for JavaScript - Blob
 

--- a/docs-ref-services/legacy/storage/storage-file-datalake-readme.md
+++ b/docs-ref-services/legacy/storage/storage-file-datalake-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: javascript
 ms.service: storage
 ms.subservice: data-lake-storage-gen2
-ms.technology: azure
 ---
 # Azure Storage File Data Lake client library for JavaScript - version 12.2.0 
 

--- a/docs-ref-services/legacy/storage/storage-file-share-readme.md
+++ b/docs-ref-services/legacy/storage/storage-file-share-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: javascript
 ms.service: storage
 ms.subservice: files
-ms.technology: azure
 ---
 # Azure Storage File Share client library for JavaScript - version 12.3.0 
 

--- a/docs-ref-services/legacy/storage/storage-fileshare-readme.md
+++ b/docs-ref-services/legacy/storage/storage-fileshare-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: javascript
 ms.service: storage
 ms.subservice: files
-ms.technology: azure
 manager: twolley
 ---
 # Azure Files for JavaScript Readme - Version 12.1.1

--- a/docs-ref-services/legacy/storage/storage-overview.md
+++ b/docs-ref-services/legacy/storage/storage-overview.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: JavaScript
 ms.service: storage
 manager: twolley
-ms.technology: azure
 ---
 ## Azure Storage SDK for JavaScript - legacy
 

--- a/docs-ref-services/legacy/storage/storage-queue-readme.md
+++ b/docs-ref-services/legacy/storage/storage-queue-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: javascript
 ms.service: storage
 ms.subservice: queues
-ms.technology: azure
 ---
 # Azure Storage SDK V10 for JavaScript - Queue
 

--- a/docs-ref-services/legacy/traffic-manager.md
+++ b/docs-ref-services/legacy/traffic-manager.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: traffic-manager
 manager: jeconnoc
-ms.technology: azure
 ---
 # Azure Traffic Manager modules for JavaScript
 

--- a/docs-ref-services/legacy/virtual-machines.md
+++ b/docs-ref-services/legacy/virtual-machines.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: big-compute
 manager: jeconnoc
-ms.technology: azure
 ---
 # Azure Virtual Machine Modules for JavaScript
 

--- a/docs-ref-services/legacy/virtual-network.md
+++ b/docs-ref-services/legacy/virtual-network.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: virtual-network
 manager: jeconnoc
-ms.technology: azure
 ---
 # Azure Virtual Network modules for JavaScript
 

--- a/docs-ref-services/preview/active-directory.md
+++ b/docs-ref-services/preview/active-directory.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: active-directory
 manager: mtillman
-ms.technology: azure
 ---
 # Azure Active Directory modules for Node.js
 

--- a/docs-ref-services/preview/ai-metrics-advisor-readme.md
+++ b/docs-ref-services/preview/ai-metrics-advisor-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: javascript
 ms.service: applied-ai-services
 ms.subservice: metrics-advisor
-ms.technology: azure
 ---
 # Azure Metrics Advisor client library for JavaScript - version 1.0.0-beta.4 
 

--- a/docs-ref-services/preview/arm-commitmentplans-readme.md
+++ b/docs-ref-services/preview/arm-commitmentplans-readme.md
@@ -5,7 +5,6 @@ ms.date: 04/28/2022
 ms.topic: reference
 ms.devlang: javascript
 ms.service: machine-learning
-ms.technology: azure
 ---
 # Azure ML Commitment Plans Management client library for JavaScript - version 2.0.0-beta.2 
 

--- a/docs-ref-services/preview/arm-loadtestservice-readme.md
+++ b/docs-ref-services/preview/arm-loadtestservice-readme.md
@@ -5,7 +5,6 @@ ms.date: 04/27/2022
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure
-ms.technology: azure
 ---
 # Azure LoadTest client library for JavaScript - version 1.0.0-beta.2 
 

--- a/docs-ref-services/preview/arm-servicemap-readme.md
+++ b/docs-ref-services/preview/arm-servicemap-readme.md
@@ -5,7 +5,6 @@ ms.date: 01/21/2022
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure-maps
-ms.technology: azure
 ---
 # Azure Service client library for JavaScript - version 3.0.0-beta.1 
 

--- a/docs-ref-services/preview/arm-template-readme.md
+++ b/docs-ref-services/preview/arm-template-readme.md
@@ -5,7 +5,6 @@ ms.date: 06/25/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure
-ms.technology: azure
 ---
 # Azure IoTSpaces client library for JavaScript - version 1.0.0-beta.2 
 

--- a/docs-ref-services/preview/arm-videoanalyzer-readme.md
+++ b/docs-ref-services/preview/arm-videoanalyzer-readme.md
@@ -5,7 +5,6 @@ ms.date: 12/17/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure-video-analyzer
-ms.technology: azure
 ---
 # Azure VideoAnalyzerManagement client library for JavaScript - version 1.0.0-beta.2 
 

--- a/docs-ref-services/preview/attestation-readme.md
+++ b/docs-ref-services/preview/attestation-readme.md
@@ -5,7 +5,6 @@ ms.date: 06/16/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: attestation
-ms.technology: azure
 ---
 # Azure Attestation client library for JavaScript - version 1.0.0-beta.4 
 

--- a/docs-ref-services/preview/batch-ai.md
+++ b/docs-ref-services/preview/batch-ai.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: batch-ai
 manager: cjgronlund
-ms.technology: azure
 ---
 # Batch AI Modules for JavaScript
 

--- a/docs-ref-services/preview/billing.md
+++ b/docs-ref-services/preview/billing.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: billing
 manager: timlt
-ms.technology: 
 ms.product: 
 ---
 # Azure Billing modules for JavaScript

--- a/docs-ref-services/preview/cdn.md
+++ b/docs-ref-services/preview/cdn.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: azure-cdn
 manager: v-laurab
-ms.technology: azure
 ---
 # Azure CDN modules for JavaScript
 

--- a/docs-ref-services/preview/cognitiveservices-autosuggest-readme.md
+++ b/docs-ref-services/preview/cognitiveservices-autosuggest-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Autosuggest
 

--- a/docs-ref-services/preview/cognitiveservices-customimagesearch-readme.md
+++ b/docs-ref-services/preview/cognitiveservices-customimagesearch-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Custom Image Search
 

--- a/docs-ref-services/preview/cognitiveservices-customsearch-readme.md
+++ b/docs-ref-services/preview/cognitiveservices-customsearch-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Custom Search
 

--- a/docs-ref-services/preview/cognitiveservices-entitysearch-readme.md
+++ b/docs-ref-services/preview/cognitiveservices-entitysearch-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Entity Search
 

--- a/docs-ref-services/preview/cognitiveservices-imagesearch-readme.md
+++ b/docs-ref-services/preview/cognitiveservices-imagesearch-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Image Search
 

--- a/docs-ref-services/preview/cognitiveservices-newssearch-readme.md
+++ b/docs-ref-services/preview/cognitiveservices-newssearch-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing News Search
 

--- a/docs-ref-services/preview/cognitiveservices-spellcheck-readme.md
+++ b/docs-ref-services/preview/cognitiveservices-spellcheck-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Spell Check
 

--- a/docs-ref-services/preview/cognitiveservices-videosearch-readme.md
+++ b/docs-ref-services/preview/cognitiveservices-videosearch-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Video Search
 

--- a/docs-ref-services/preview/cognitiveservices-visualsearch-readme.md
+++ b/docs-ref-services/preview/cognitiveservices-visualsearch-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Visual Search
 

--- a/docs-ref-services/preview/cognitiveservices-websearch-readme.md
+++ b/docs-ref-services/preview/cognitiveservices-websearch-readme.md
@@ -4,7 +4,6 @@ ms.date: 10/26/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: bing-search-services
-ms.technology: azure
 ---
 # Bing Web Search API
 

--- a/docs-ref-services/preview/communication-administration-readme.md
+++ b/docs-ref-services/preview/communication-administration-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/16/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure-communication-services
-ms.technology: azure
 ---
 # Azure Communication Administration client library for JavaScript - version 1.0.0-beta.3 
 

--- a/docs-ref-services/preview/communication-common-readme.md
+++ b/docs-ref-services/preview/communication-common-readme.md
@@ -5,7 +5,6 @@ ms.date: 03/29/2023
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure-communication-services
-ms.technology: azure
 ---
 # Azure Communication Common client library for JavaScript - version 3.0.0-beta.1 
 

--- a/docs-ref-services/preview/core-auth-readme.md
+++ b/docs-ref-services/preview/core-auth-readme.md
@@ -5,7 +5,6 @@ ms.date: 06/30/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure
-ms.technology: azure
 ---
 ## Azure Core Authentication
 

--- a/docs-ref-services/preview/core-client-paging-rest-readme.md
+++ b/docs-ref-services/preview/core-client-paging-rest-readme.md
@@ -5,7 +5,6 @@ ms.date: 08/06/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure
-ms.technology: azure
 ---
 # Azure Rest Core Paging library for JavaScript (Experimental)
 

--- a/docs-ref-services/preview/core-client-readme.md
+++ b/docs-ref-services/preview/core-client-readme.md
@@ -5,7 +5,6 @@ ms.date: 03/10/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure
-ms.technology: azure
 ---
 # Azure Core Service client library for JavaScript - version 1.0.0-beta.2 
  (Experimental)

--- a/docs-ref-services/preview/core-http-readme.md
+++ b/docs-ref-services/preview/core-http-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/06/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure
-ms.technology: azure
 ---
 # Azure Core HTTP client library for JavaScript - version 1.2.0 
 

--- a/docs-ref-services/preview/core-https-readme.md
+++ b/docs-ref-services/preview/core-https-readme.md
@@ -5,7 +5,6 @@ ms.date: 02/05/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure
-ms.technology: azure
 ---
 # Azure Core HTTP client library for JavaScript - version 1.0.0-beta.1 
  (Experimental)

--- a/docs-ref-services/preview/core-paging-readme.md
+++ b/docs-ref-services/preview/core-paging-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/30/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure
-ms.technology: azure
 ---
 # Azure Core Paging client library for JavaScript - version 1.1.3 
 

--- a/docs-ref-services/preview/core-rest-pipeline-readme.md
+++ b/docs-ref-services/preview/core-rest-pipeline-readme.md
@@ -5,7 +5,6 @@ ms.date: 06/04/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure
-ms.technology: azure
 ---
 # Azure Core HTTP client library for JavaScript - version 1.1.0-beta.3 
  (Experimental)

--- a/docs-ref-services/preview/core-util-readme.md
+++ b/docs-ref-services/preview/core-util-readme.md
@@ -5,7 +5,6 @@ ms.date: 05/07/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure
-ms.technology: azure
 ---
 # Azure Core Util client library for JavaScript - version 1.0.0-beta.1 
  (Experimental)

--- a/docs-ref-services/preview/core-xml-readme.md
+++ b/docs-ref-services/preview/core-xml-readme.md
@@ -5,7 +5,6 @@ ms.date: 02/05/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure
-ms.technology: azure
 ---
 # Azure Core XML client library for JavaScript - version 1.0.0-beta.1 
  (Experimental)

--- a/docs-ref-services/preview/cosmos-readme.md
+++ b/docs-ref-services/preview/cosmos-readme.md
@@ -5,7 +5,6 @@ ms.date: 11/09/2020
 ms.topic: reference
 ms.devlang: javascript
 ms.service: cosmos-db
-ms.technology: azure
 ---
 # Azure Cosmos DB client library for JavaScript - version 3.9.3 
 /TypeScript

--- a/docs-ref-services/preview/data-tables-readme.md
+++ b/docs-ref-services/preview/data-tables-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: javascript
 ms.service: storage
 ms.subservice: tables
-ms.technology: azure
 ---
 # Azure Tables client library for JavaScript - version 12.0.0-beta.3 
 

--- a/docs-ref-services/preview/datalake-store.md
+++ b/docs-ref-services/preview/datalake-store.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: data-lake-store
 manager: routlaw
-ms.technology: azure
 ---
 # Azure Data Lake Store modules for Node.JS
 

--- a/docs-ref-services/preview/dns.md
+++ b/docs-ref-services/preview/dns.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: dns
 manager: jeconnoc
-ms.technology: azure
 ---
 # Azure DNS modules for JavaScript
 

--- a/docs-ref-services/preview/dtdl-parser-readme.md
+++ b/docs-ref-services/preview/dtdl-parser-readme.md
@@ -5,7 +5,6 @@ ms.date: 02/23/2022
 ms.topic: reference
 ms.devlang: javascript
 ms.service: digital-twins
-ms.technology: azure
 ---
 # Azure Model Parser client library for JavaScript - version 1.0.0-beta.2 
 

--- a/docs-ref-services/preview/iot-device-update-readme.md
+++ b/docs-ref-services/preview/iot-device-update-readme.md
@@ -5,7 +5,6 @@ ms.date: 03/04/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: iot-hub-device-update
-ms.technology: azure
 ---
 # Azure Device Update for IoT Hub client library for JavaScript - version 1.0.0-beta.1 
 

--- a/docs-ref-services/preview/iot-hub.md
+++ b/docs-ref-services/preview/iot-hub.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: javascript
 ms.service: iot-hub
 manager: timlt
-ms.technology: azure
 ---
 # Azure IoT Hub modules for JavaScript
 

--- a/docs-ref-services/preview/iot-modelsrepository-readme.md
+++ b/docs-ref-services/preview/iot-modelsrepository-readme.md
@@ -5,7 +5,6 @@ ms.date: 05/28/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure
-ms.technology: azure
 ---
 # Azure IoT Models Repository client library for JavaScript - version 1.0.0-beta.2 
 

--- a/docs-ref-services/preview/key-vault/key-vault-index.md
+++ b/docs-ref-services/preview/key-vault/key-vault-index.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: key-vault
 manager: mbaldwin
-ms.technology: azure
 ---
 ## Azure Key Vault SDK for JavaScript - preview
 

--- a/docs-ref-services/preview/key-vault/keyvault-admin-readme.md
+++ b/docs-ref-services/preview/key-vault/keyvault-admin-readme.md
@@ -5,7 +5,6 @@ ms.date: 08/10/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: key-vault
-ms.technology: azure
 ---
 # Azure Key Vault Administration client library for JavaScript - version 4.2.0-beta.1 
 

--- a/docs-ref-services/preview/key-vault/keyvault-certificates-readme.md
+++ b/docs-ref-services/preview/key-vault/keyvault-certificates-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/07/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: key-vault
-ms.technology: azure
 ---
 # Azure Key Vault Certificates client library for JavaScript - version 4.4.0-beta.1 
 

--- a/docs-ref-services/preview/key-vault/keyvault-keys-readme.md
+++ b/docs-ref-services/preview/key-vault/keyvault-keys-readme.md
@@ -5,7 +5,6 @@ ms.date: 08/10/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: key-vault
-ms.technology: azure
 ---
 # Azure Key Vault Key client library for JavaScript - version 4.4.0-beta.1 
 

--- a/docs-ref-services/preview/key-vault/keyvault-secrets-readme.md
+++ b/docs-ref-services/preview/key-vault/keyvault-secrets-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/07/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: key-vault
-ms.technology: azure
 ---
 # Azure Key Vault Secret client library for JavaScript - version 4.4.0-beta.1 
 

--- a/docs-ref-services/preview/mixed-reality-authentication-readme.md
+++ b/docs-ref-services/preview/mixed-reality-authentication-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/21/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure
-ms.technology: azure
 ---
 # Azure Mixed Reality Authentication client library for JavaScript - version 1.0.0-beta.1 
 

--- a/docs-ref-services/preview/mixed-reality-remote-rendering-readme.md
+++ b/docs-ref-services/preview/mixed-reality-remote-rendering-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/21/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure-remote-rendering
-ms.technology: azure
 ---
 # Azure Remote Rendering client library for JavaScript - version 1.0.0-beta.1 
 

--- a/docs-ref-services/preview/opentelemetry-exporter-azure-monitor-readme.md
+++ b/docs-ref-services/preview/opentelemetry-exporter-azure-monitor-readme.md
@@ -5,7 +5,6 @@ ms.date: 01/20/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure-monitor
-ms.technology: azure
 ---
 # Azure Monitor OpenTelemetry Exporter client library for JavaScript - version 1.0.0-beta.2 
 

--- a/docs-ref-services/preview/power-bi.md
+++ b/docs-ref-services/preview/power-bi.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: power-bi-embedded
 manager: kfile
-ms.technology: azure
 ---
 # Azure PowerBI Embedded modules for JavaScript
 

--- a/docs-ref-services/preview/purview-administration-rest-readme.md
+++ b/docs-ref-services/preview/purview-administration-rest-readme.md
@@ -5,7 +5,6 @@ ms.date: 10/15/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: purview
-ms.technology: azure
 ---
 # Azure Purview Administration REST client library for JavaScript - version 1.0.0-beta.1 
 

--- a/docs-ref-services/preview/purview-scanning-rest-readme.md
+++ b/docs-ref-services/preview/purview-scanning-rest-readme.md
@@ -5,7 +5,6 @@ ms.date: 10/15/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: purview
-ms.technology: azure
 ---
 # Azure Purview Scanning Rest-Level client library for JavaScript - version 1.0.0-beta.2 
 

--- a/docs-ref-services/preview/quantum-jobs-readme.md
+++ b/docs-ref-services/preview/quantum-jobs-readme.md
@@ -5,7 +5,6 @@ ms.date: 02/05/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: azure-quantum
-ms.technology: azure
 ---
 ## Azure Quantum Jobs client library for JavaScript - version 1.0.0-beta.1 
 

--- a/docs-ref-services/preview/relay.md
+++ b/docs-ref-services/preview/relay.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: service-bus-relay
 manager: timlt
-ms.technology: azure
 ---
 # Azure Relay modules for JavaScript
 

--- a/docs-ref-services/preview/scheduler.md
+++ b/docs-ref-services/preview/scheduler.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: scheduler
 manager: angrobe
-ms.technology: azure
 ---
 # Azure Scheduler modules for JavaScript
 

--- a/docs-ref-services/preview/server-management.md
+++ b/docs-ref-services/preview/server-management.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: azure-asm
 manager: angrobe
-ms.technology: azure
 ---
 # Azure Server Management modules for JavaScript
 

--- a/docs-ref-services/preview/service-bus-readme-legacy.md
+++ b/docs-ref-services/preview/service-bus-readme-legacy.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: service-bus
 manager: timlt
-ms.technology: azure
 ---
 # Microsoft Azure SDK for Node.js - azure-sb - Version 0.11.1
 

--- a/docs-ref-services/preview/site-recovery.md
+++ b/docs-ref-services/preview/site-recovery.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: site-recovery
 manager: carmonm
-ms.technology: azure
 ---
 # Azure Site Recovery modules for JavaScript
 

--- a/docs-ref-services/preview/storage-fileshare-readme.md
+++ b/docs-ref-services/preview/storage-fileshare-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: javascript
 ms.service: storage
 manager: twolley
-ms.technology: azure
 ms.subservice: files
 ---
 # Azure Files for JavaScript Readme - Version 12.1.1

--- a/docs-ref-services/preview/storage/storage-blob-changefeed-readme.md
+++ b/docs-ref-services/preview/storage/storage-blob-changefeed-readme.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: javascript
 ms.service: storage
 ms.subservice: blobs
-ms.technology: azure
 ---
 # Azure Storage Blob Change Feed client library for JavaScript - version 12.0.0-preview.2
 

--- a/docs-ref-services/preview/storage/storage-overview.md
+++ b/docs-ref-services/preview/storage/storage-overview.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: JavaScript
 ms.service: storage
 manager: twolley
-ms.technology: azure
 ---
 ## Azure Storage SDK for JavaScript - preview
 

--- a/docs-ref-services/preview/synapse-access-control-readme.md
+++ b/docs-ref-services/preview/synapse-access-control-readme.md
@@ -5,7 +5,6 @@ ms.date: 08/11/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: synapse-analytics
-ms.technology: azure
 ---
 ## Azure Synapse Access Control client library for JavaScript - version 1.0.0-beta.3 
 

--- a/docs-ref-services/preview/synapse-managed-private-endpoints-readme.md
+++ b/docs-ref-services/preview/synapse-managed-private-endpoints-readme.md
@@ -5,7 +5,6 @@ ms.date: 09/08/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: synapse-analytics
-ms.technology: azure
 ---
 ## Azure Synapse Managed Private Endpoints client library for JavaScript - version 1.0.0-beta.4 
 

--- a/docs-ref-services/preview/synapse-monitoring-readme.md
+++ b/docs-ref-services/preview/synapse-monitoring-readme.md
@@ -5,7 +5,6 @@ ms.date: 02/09/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: synapse-analytics
-ms.technology: azure
 ---
 ## Azure Synapse Monitoring client library for JavaScript - version 1.0.0-beta.2 
 

--- a/docs-ref-services/preview/synapse-spark-readme.md
+++ b/docs-ref-services/preview/synapse-spark-readme.md
@@ -5,7 +5,6 @@ ms.date: 10/05/2021
 ms.topic: reference
 ms.devlang: javascript
 ms.service: synapse-analytics
-ms.technology: azure
 ---
 ## Azure Synapse Spark client library for JavaScript - version 1.0.0-beta.4 
 

--- a/docs-ref-services/preview/traffic-manager.md
+++ b/docs-ref-services/preview/traffic-manager.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: javascript
 ms.service: trafficmanager
 manager: jeconnoc
-ms.technology: azure
 ---
 # Azure Traffic Manager modules for JavaScript
 

--- a/docs-ref-services/preview/virtual-machines.md
+++ b/docs-ref-services/preview/virtual-machines.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: big-compute
 manager: jeconnoc
-ms.technology: azure
 ---
 # Azure Virtual Machine Modules for JavaScript
 

--- a/docs-ref-services/preview/virtual-network.md
+++ b/docs-ref-services/preview/virtual-network.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: virtual-network
 manager: jeconnoc
-ms.technology: azure
 ---
 # Azure Virtual Network modules for JavaScript
 


### PR DESCRIPTION
These files are updated by automation, but that automation no longer attempts to include ms.prod and ms.technology metadata - they only persist because they're already on the files and the automation preserves them.