### PR TITLE
Remove empty and invalid metadata tag

### DIFF
--- a/docs-ref-services/legacy/billing.md
+++ b/docs-ref-services/legacy/billing.md
@@ -6,7 +6,6 @@ ms.topic: reference
 ms.devlang: nodejs
 ms.service: billing
 manager: timlt
-ms.product: 
 ---
 # Azure Billing modules for JavaScript
 


### PR DESCRIPTION
Diff is weird, but this just removes the `ms.product` line. Looks better if you [hide whitespace](https://github.com/MicrosoftDocs/azure-docs-sdk-node/pull/1722/changes?w=1).